### PR TITLE
Feat/#5 JaCoCo 설정 추가 및 테스트 커버리지 리포트 생성 

### DIFF
--- a/logbat/build.gradle
+++ b/logbat/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'info'
@@ -39,6 +40,53 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/config/**',
+                    '**/Application*',
+                    '**/*$*',
+                    '**/dto/**',
+                    '**/entity/**'
+            ])
+        }))
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+        }
+        rule {
+            element = 'CLASS'
+            excludes = [
+                    '**/config/**',
+                    '**/Application*',
+                    '**/*$*',
+                    '**/dto/**',
+                    '**/entity/**'
+            ]
+        }
+    }
 }

--- a/logbat/build.gradle
+++ b/logbat/build.gradle
@@ -32,10 +32,9 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    // MySQL Connector J
+    // MySQL Connector
     runtimeOnly 'com.mysql:mysql-connector-j'
-
-    // SprintBoot Test
+    // SpringBoot Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
## 🚀 개발 사항
- JaCoCo 플러그인 추가 및 설정
- 테스트 커버리지 리포트 생성 태스크 설정
- 커버리지 검증 규칙 추가
- 특정 패키지 및 클래스 제외 설정

### 이슈 번호

- close #5 

## 특이 사항 🫶 
