### PR TITLE
Feat/#15 Project 도메인 모델 구현

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/project/domain/Project.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/Project.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,7 +42,7 @@ public class Project {
     }
 
     public static Project from(String name) {
-        if (name == null || name.isBlank()) {
+        if (name == null || name.isBlank() || name.getBytes(StandardCharsets.UTF_8).length > 100) {
             throw new IllegalArgumentException("잘못된 이름 요청입니다.");
         }
         return new Project(name);

--- a/logbat/src/main/java/info/logbat/domain/project/domain/Project.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/Project.java
@@ -1,0 +1,50 @@
+package info.logbat.domain.project.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Getter
+@SoftDelete
+@Table(name = "projects")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    private Project(String name) {
+        this.name = name;
+    }
+
+    public static Project from(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("잘못된 이름 요청입니다.");
+        }
+        return new Project(name);
+    }
+
+}

--- a/logbat/src/main/java/info/logbat/domain/project/repository/ProjectJpaRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/project/repository/ProjectJpaRepository.java
@@ -1,0 +1,10 @@
+package info.logbat.domain.project.repository;
+
+import info.logbat.domain.project.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
+
+}

--- a/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
@@ -45,7 +45,8 @@ class ProjectTest {
             return Stream.of(
                 Arguments.of(""),
                 Arguments.of((String) null),
-                Arguments.of("   ")
+                Arguments.of("   "),
+                Arguments.of("한글33자이상이면예외가발생해야할것같은데진짜발생하는지확인하기위한테스트값입니다.")
             );
         }
 

--- a/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
@@ -1,0 +1,52 @@
+package info.logbat.domain.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Project 도메인은")
+class ProjectTest {
+
+    @DisplayName("생성시")
+    @Nested
+    class whenCreated {
+
+        @DisplayName("이름이 잘못된 경우 예외를 던진다.")
+        @ParameterizedTest
+        @MethodSource("exceptionValues")
+        void testFromMethodFailWhenNameValueNotVerified(String name) {
+            // Act & Assert
+            assertThatThrownBy(() -> Project.from(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 이름 요청입니다.");
+        }
+
+        @Test
+        @DisplayName("정상적으로 생성된다.")
+        void testFromMethodSuccess() {
+            // Arrange
+            String expectedProjectName = "이름";
+            // Act
+            Project actualResult = Project.from(expectedProjectName);
+            // Assert
+            assertThat(actualResult)
+                .hasFieldOrPropertyWithValue("name", expectedProjectName);
+        }
+
+
+        private static Stream<Arguments> exceptionValues() {
+            return Stream.of(
+                Arguments.of(""),
+                Arguments.of((String) null)
+            );
+        }
+
+    }
+}

--- a/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/ProjectTest.java
@@ -21,7 +21,7 @@ class ProjectTest {
         @DisplayName("이름이 잘못된 경우 예외를 던진다.")
         @ParameterizedTest
         @MethodSource("exceptionValues")
-        void testFromMethodFailWhenNameValueNotVerified(String name) {
+        void throwsExceptionForInvalidName(String name) {
             // Act & Assert
             assertThatThrownBy(() -> Project.from(name))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -44,7 +44,8 @@ class ProjectTest {
         private static Stream<Arguments> exceptionValues() {
             return Stream.of(
                 Arguments.of(""),
-                Arguments.of((String) null)
+                Arguments.of((String) null),
+                Arguments.of("   ")
             );
         }
 


### PR DESCRIPTION
## 🚀 개발 사항

- Project 도메인 엔티티를 구현했습니다.

| 필드 | 설명 |
|---|---|
| id | DB PK |
| name | 프로젝트 명 (NotNull) |
| created_at | 생성 일자 |
| updated_at | 업데이트 일자 | 

- Hibernate 활용 Soft Deletion 을 적용했습니다. 


### 이슈 번호

- close #15 

## 특이 사항 🫶 

- 추가가 필요할 것 같은 필드 있으면 이유랑 함께 적어주세요 :D