### PR TITLE
Feat/#23 Log를 저장할 수 있는 기능 추가

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/log/domain/Log.java
+++ b/logbat/src/main/java/info/logbat/domain/log/domain/Log.java
@@ -1,7 +1,8 @@
-package info.logbat.log.domain;
+package info.logbat.domain.log.domain;
 
-import info.logbat.log.domain.enums.Level;
-import info.logbat.log.domain.values.LogData;
+import info.logbat.domain.log.domain.values.LogData;
+import info.logbat.domain.log.domain.enums.Level;
+
 import java.time.LocalDateTime;
 import lombok.Getter;
 

--- a/logbat/src/main/java/info/logbat/domain/log/domain/enums/Level.java
+++ b/logbat/src/main/java/info/logbat/domain/log/domain/enums/Level.java
@@ -1,4 +1,4 @@
-package info.logbat.log.domain.enums;
+package info.logbat.domain.log.domain.enums;
 
 public enum Level {
   ERROR,

--- a/logbat/src/main/java/info/logbat/domain/log/domain/values/LogData.java
+++ b/logbat/src/main/java/info/logbat/domain/log/domain/values/LogData.java
@@ -1,4 +1,4 @@
-package info.logbat.log.domain.values;
+package info.logbat.domain.log.domain.values;
 
 import lombok.Getter;
 

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -1,0 +1,59 @@
+package info.logbat.domain.log.repository;
+
+import info.logbat.domain.log.domain.Log;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@AllArgsConstructor
+public class LogRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public long save(Log log) {
+    String sql = "INSERT INTO logs (application_id, level, log_data, timestamp) VALUES (?, ?, ?, ?)";
+
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+
+    jdbcTemplate.update(connection -> {
+      PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+      ps.setLong(1, log.getApplicationId());
+      ps.setString(2, log.getLevel().name());
+      ps.setString(3, log.getLogData().getValue());
+      ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
+      return ps;
+    }, keyHolder);
+
+    if (keyHolder.getKey() == null) {
+      throw new IllegalStateException("로그 저장에 실패했습니다.");
+    }
+
+    return keyHolder.getKey().longValue();
+  }
+
+  public Optional<Log> findById(Long logId) {
+    String sql = "SELECT * FROM logs WHERE log_id = ?";
+
+    Log log = jdbcTemplate.queryForObject(sql, logRowMapper(), logId);
+
+    return Optional.ofNullable(log);
+  }
+
+  private RowMapper<Log> logRowMapper() {
+    return (rs, rowNum) -> new Log(
+        rs.getLong("log_id"),
+        rs.getLong("application_id"),
+        rs.getString("level"),
+        rs.getString("log_data"),
+        rs.getTimestamp("timestamp").toLocalDateTime()
+    );
+  }
+}

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -42,18 +42,19 @@ public class LogRepository {
   public Optional<Log> findById(Long logId) {
     String sql = "SELECT * FROM logs WHERE log_id = ?";
 
-    Log log = jdbcTemplate.queryForObject(sql, logRowMapper(), logId);
-
-    return Optional.ofNullable(log);
+    return Optional.ofNullable(
+        jdbcTemplate.queryForObject(
+            sql,
+            LOG_ROW_MAPPER,
+            logId
+        ));
   }
 
-  private RowMapper<Log> logRowMapper() {
-    return (rs, rowNum) -> new Log(
-        rs.getLong("log_id"),
-        rs.getLong("application_id"),
-        rs.getString("level"),
-        rs.getString("log_data"),
-        rs.getTimestamp("timestamp").toLocalDateTime()
-    );
-  }
+  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
+      rs.getLong("log_id"),
+      rs.getLong("application_id"),
+      rs.getString("level"),
+      rs.getString("log_data"),
+      rs.getTimestamp("timestamp").toLocalDateTime()
+  );
 }

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -6,6 +6,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -40,12 +41,16 @@ public class LogRepository {
   public Optional<Log> findById(Long logId) {
     String sql = "SELECT * FROM logs WHERE log_id = ?";
 
-    return Optional.ofNullable(
-        jdbcTemplate.queryForObject(
-            sql,
-            LOG_ROW_MAPPER,
-            logId
-        ));
+    try {
+      return Optional.ofNullable(
+          jdbcTemplate.queryForObject(
+              sql,
+              LOG_ROW_MAPPER,
+              logId
+          ));
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
   }
 
   private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -32,11 +32,9 @@ public class LogRepository {
       return ps;
     }, keyHolder);
 
-    if (keyHolder.getKey() == null) {
-      throw new IllegalStateException("로그 저장에 실패했습니다.");
-    }
-
-    return keyHolder.getKey().longValue();
+    return Optional.ofNullable(keyHolder.getKey())
+        .map(Number::longValue)
+        .orElseThrow(() -> new IllegalStateException("로그 저장에 실패했습니다."));
   }
 
   public Optional<Log> findById(Long logId) {

--- a/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 @DisplayName("LogRepository 테스트")
 class LogRepositoryTest {
 

--- a/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
@@ -61,4 +61,16 @@ class LogRepositoryTest {
             LocalDateTime.of(2021, 1, 1, 0, 0, 0));
   }
 
+  @DisplayName("없는 Log를 조회하면 빈 Optional을 반환한다.")
+  @Test
+  void findNonexistentLog() {
+    // given
+    long 없는_로그_ID = 1L;
+
+    // when
+    Optional<Log> 저장된_로그 = logRepository.findById(없는_로그_ID);
+
+    // then
+    assertThat(저장된_로그).isEmpty();
+  }
 }

--- a/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/LogRepositoryTest.java
@@ -1,0 +1,62 @@
+package info.logbat.domain.log.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import info.logbat.domain.log.domain.Log;
+import info.logbat.domain.log.domain.enums.Level;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayName("LogRepository 테스트")
+class LogRepositoryTest {
+
+  @Autowired
+  private LogRepository logRepository;
+
+  @DisplayName("Log를 저장할 수 있다.")
+  @Test
+  void saveLog() {
+    // given
+    String 로그_레벨 = "INFO";
+    String 로그_데이터 = "테스트_로그_데이터";
+    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+
+    Log 로그 = new Log(1L, 로그_레벨, 로그_데이터, 타임스탬프);
+
+    // when
+    long 저장된_ID = logRepository.save(로그);
+
+    // then
+    assertThat(저장된_ID)
+        .isPositive();
+  }
+
+  @DisplayName("저장한 Log를 조회할 수 있다.")
+  @Test
+  void findLog() {
+    // given
+    String 로그_레벨 = "INFO";
+    String 로그_데이터 = "테스트_로그_데이터";
+    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+
+    long 로그_ID = logRepository.save(new Log(1L, 로그_레벨, 로그_데이터, 타임스탬프));
+
+    // when
+    Optional<Log> 저장된_로그 = logRepository.findById(로그_ID);
+
+    // then
+    assertThat(저장된_로그).isPresent()
+        .get()
+        .extracting("logId", "applicationId", "level", "logData.value", "timestamp")
+        .containsExactly(로그_ID, 1L, Level.INFO, "테스트_로그_데이터",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+  }
+
+}

--- a/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/LogTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/LogTest.java
@@ -1,9 +1,10 @@
-package info.logbat.log.domain;
+package info.logbat.domain.project.domain.log.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import info.logbat.log.domain.enums.Level;
+import info.logbat.domain.log.domain.Log;
+import info.logbat.domain.log.domain.enums.Level;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/enums/LevelTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/enums/LevelTest.java
@@ -1,4 +1,4 @@
-package info.logbat.log.domain.enums;
+package info.logbat.domain.project.domain.log.domain.enums;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import info.logbat.domain.log.domain.enums.Level;
 
 @DisplayName("로그 Level enum 테스트")
 class LevelTest {

--- a/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/values/LogDataTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/log/domain/values/LogDataTest.java
@@ -1,10 +1,12 @@
-package info.logbat.log.domain.values;
+package info.logbat.domain.project.domain.log.domain.values;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import info.logbat.domain.log.domain.values.LogData;
 
 @DisplayName("LogData VO 테스트")
 class LogDataTest {


### PR DESCRIPTION
## 🚀 개발 사항

- Log DDL 설계
```sql
CREATE TABLE logs (
    log_id BIGINT AUTO_INCREMENT PRIMARY KEY,
    application_id BIGINT NOT NULL,
    level ENUM('INFO', 'ERROR') NOT NULL, 
    log_data TEXT NOT NULL,
    timestamp DATETIME NOT NULL
);
```
- Log를 저장하는 LogRepository를 JdbcTemplate로 개발했습니다.
- LogRepository에서 작동하는 사항을 검증하기 위해 Test를 추가했습니다.

### 이슈 번호

- close #23 

## 특이 사항 🫶 

- Repository 테스트는 `@ActiveProfile("test")`를 추가하여 테스트 프로파일을 사용하도록 만들었습니다.
