### PR TITLE
Feat/#31 Log를 저장하는 API 구현

### DIFF
--- a/logbat/build.gradle
+++ b/logbat/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    // SpringBoot Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.1'
     // MySQL Connector
     runtimeOnly 'com.mysql:mysql-connector-j'
     // SpringBoot Test

--- a/logbat/src/main/java/info/logbat/domain/log/application/LogService.java
+++ b/logbat/src/main/java/info/logbat/domain/log/application/LogService.java
@@ -1,0 +1,27 @@
+package info.logbat.domain.log.application;
+
+import info.logbat.domain.log.application.payload.request.CreateLogServiceRequest;
+import info.logbat.domain.log.domain.Log;
+import info.logbat.domain.log.repository.LogRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+
+  private final LogRepository logRepository;
+
+  public long saveLog(CreateLogServiceRequest request) {
+    Long appId = request.applicationId();
+    String logLevel = request.logLevel();
+    String logData = request.logData();
+    LocalDateTime timestamp = request.timestamp();
+    // TODO Log 저장 전 Application ID 체크 로직 추가 필요
+
+    Log log = new Log(appId, logLevel, logData, timestamp);
+
+    return logRepository.save(log);
+  }
+}

--- a/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
@@ -1,5 +1,6 @@
 package info.logbat.domain.log.application.payload.request;
 
+import info.logbat.domain.log.presentation.payload.request.CreateLogRequest;
 import java.time.LocalDateTime;
 
 public record CreateLogServiceRequest(
@@ -9,4 +10,12 @@ public record CreateLogServiceRequest(
     LocalDateTime timestamp
 ) {
 
+  public static CreateLogServiceRequest of(Long applicationId, CreateLogRequest request) {
+    return new CreateLogServiceRequest(
+        applicationId,
+        request.getLogLevel(),
+        request.getLogData(),
+        request.getTimestamp()
+    );
+  }
 }

--- a/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
@@ -13,9 +13,9 @@ public record CreateLogServiceRequest(
   public static CreateLogServiceRequest of(Long applicationId, CreateLogRequest request) {
     return new CreateLogServiceRequest(
         applicationId,
-        request.getLogLevel(),
-        request.getLogData(),
-        request.getTimestamp()
+        request.logLevel(),
+        request.logData(),
+        request.timestamp()
     );
   }
 }

--- a/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/log/application/payload/request/CreateLogServiceRequest.java
@@ -1,0 +1,12 @@
+package info.logbat.domain.log.application.payload.request;
+
+import java.time.LocalDateTime;
+
+public record CreateLogServiceRequest(
+    Long applicationId,
+    String logLevel,
+    String logData,
+    LocalDateTime timestamp
+) {
+
+}

--- a/logbat/src/main/java/info/logbat/domain/log/presentation/LogController.java
+++ b/logbat/src/main/java/info/logbat/domain/log/presentation/LogController.java
@@ -1,0 +1,34 @@
+package info.logbat.domain.log.presentation;
+
+import info.logbat.domain.log.application.LogService;
+import info.logbat.domain.log.application.payload.request.CreateLogServiceRequest;
+import info.logbat.domain.log.presentation.payload.request.CreateLogRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LogController {
+
+  private final LogService logService;
+
+  @PostMapping("/logs")
+  public ResponseEntity<Void> saveLog(
+      @RequestHeader("app_id") @NotNull @Positive Long applicationId,
+      @Valid @RequestBody CreateLogRequest request
+  ) {
+
+    logService.saveLog(CreateLogServiceRequest.of(applicationId, request));
+
+    return ResponseEntity.ok()
+        .build();
+  }
+
+}

--- a/logbat/src/main/java/info/logbat/domain/log/presentation/payload/request/CreateLogRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/log/presentation/payload/request/CreateLogRequest.java
@@ -3,24 +3,16 @@ package info.logbat.domain.log.presentation.payload.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import lombok.Getter;
 
-@Getter
-public class CreateLogRequest {
+public record CreateLogRequest(
+    @NotBlank
+    String logLevel,
 
-  @NotBlank
-  private final String logLevel;
+    @NotBlank
+    String logData,
 
-  @NotBlank
-  private final String logData;
+    @NotNull
+    LocalDateTime timestamp
+) {
 
-  @NotNull
-  private final LocalDateTime timestamp;
-
-  public CreateLogRequest(String logLevel, String logData,
-      LocalDateTime timestamp) {
-    this.logLevel = logLevel;
-    this.logData = logData;
-    this.timestamp = timestamp;
-  }
 }

--- a/logbat/src/main/java/info/logbat/domain/log/presentation/payload/request/CreateLogRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/log/presentation/payload/request/CreateLogRequest.java
@@ -1,0 +1,26 @@
+package info.logbat.domain.log.presentation.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CreateLogRequest {
+
+  @NotBlank
+  private final String logLevel;
+
+  @NotBlank
+  private final String logData;
+
+  @NotNull
+  private final LocalDateTime timestamp;
+
+  public CreateLogRequest(String logLevel, String logData,
+      LocalDateTime timestamp) {
+    this.logLevel = logLevel;
+    this.logData = logData;
+    this.timestamp = timestamp;
+  }
+}

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -5,7 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -14,7 +14,7 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LogRepository {
 
   private final JdbcTemplate jdbcTemplate;

--- a/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
+++ b/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
@@ -1,0 +1,35 @@
+package info.logbat.domain.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import info.logbat.domain.log.application.LogService;
+import info.logbat.domain.log.presentation.LogController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 이후 테스트 하려면 Controller에 대해 controllers에 추가하고, ControllerTestSupport를 상속받아 테스트를 진행하시면 됩니다.
+ */
+@WebMvcTest(controllers = {
+    LogController.class
+}
+)
+@ActiveProfiles("test")
+public abstract class ControllerTestSupport {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockBean
+  protected LogService logService;
+
+  /**
+   * 이후 필요한 서비스에 대해 MockBean을 추가하여 테스트를 진행하시면 됩니다.
+   */
+
+}

--- a/logbat/src/test/java/info/logbat/domain/log/application/LogServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/application/LogServiceTest.java
@@ -1,0 +1,53 @@
+package info.logbat.domain.log.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import info.logbat.domain.log.application.payload.request.CreateLogServiceRequest;
+import info.logbat.domain.log.domain.Log;
+import info.logbat.domain.log.domain.enums.Level;
+import info.logbat.domain.log.repository.LogRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("LogService 테스트")
+class LogServiceTest {
+
+  @Autowired
+  private LogService logService;
+
+  @Autowired
+  private LogRepository logRepository;
+
+  @DisplayName("Log를 저장할 수 있다.")
+  @Test
+  void saveLog() {
+    // given
+    Long 어플리케이션_ID = 1L;
+    String 로그_레벨 = "INFO";
+    String 로그_데이터 = "테스트_로그_데이터";
+    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+
+    CreateLogServiceRequest 요청_DTO = new CreateLogServiceRequest(어플리케이션_ID, 로그_레벨, 로그_데이터, 타임스탬프);
+
+    // when
+    long 저장된_ID = logService.saveLog(요청_DTO);
+
+    // then
+    Optional<Log> 찾은_로그 = logRepository.findById(저장된_ID);
+
+    assertThat(찾은_로그).isPresent()
+        .get()
+        .extracting("logId", "applicationId", "level", "logData.value", "timestamp")
+        .contains(저장된_ID, 1L, Level.INFO, "테스트_로그_데이터", 타임스탬프);
+  }
+
+}

--- a/logbat/src/test/java/info/logbat/domain/log/presentation/LogControllerTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/presentation/LogControllerTest.java
@@ -1,0 +1,102 @@
+package info.logbat.domain.log.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import info.logbat.domain.common.ControllerTestSupport;
+import info.logbat.domain.log.presentation.payload.request.CreateLogRequest;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class LogControllerTest extends ControllerTestSupport {
+
+  @DisplayName("[POST] 로그를 정상적으로 생성한다.")
+  @Test
+  void createLog() throws Exception {
+    // given
+    Long 어플리케이션_ID = 1L;
+    String 로그_레벨 = "INFO";
+    String 로그_데이터 = "테스트_로그_데이터";
+    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+
+    CreateLogRequest 요청_DTO = new CreateLogRequest(로그_레벨, 로그_데이터, 타임스탬프);
+
+    when(logService.saveLog(any()))
+        .thenReturn(1L);
+
+    // when
+    ResultActions perform = mockMvc.perform(post("/logs")
+        .contentType(MediaType.APPLICATION_JSON)
+        .header("app_id", 어플리케이션_ID)
+        .content(objectMapper.writeValueAsString(요청_DTO)));
+
+    // then
+    perform.andExpect(status().isOk());
+  }
+
+  @DisplayName("[POST] 어플리케이션_ID가 없으면 400 에러를 반환한다.")
+  @Test
+  void createLogWithoutAppId() throws Exception {
+    // given
+    String 로그_레벨 = "INFO";
+    String 로그_데이터 = "테스트_로그_데이터";
+    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+
+    CreateLogRequest 요청_DTO = new CreateLogRequest(로그_레벨, 로그_데이터, 타임스탬프);
+
+    when(logService.saveLog(any()))
+        .thenReturn(1L);
+
+    // when
+    ResultActions perform = mockMvc.perform(post("/logs")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(요청_DTO)));
+
+    // then
+    perform.andExpect(status().isBadRequest());
+  }
+
+  @DisplayName("[POST] 잘못된 입력으로 로그 생성 시 400 에러를 반환한다.")
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("invalidLogCreationInputs")
+  void createLogWithInvalidInput(String testCase, Long appId, String level, String data,
+      LocalDateTime timestamp) throws Exception {
+    // given
+    CreateLogRequest 요청_DTO = new CreateLogRequest(level, data, timestamp);
+    when(logService.saveLog(any())).thenReturn(1L);
+
+    // when
+    ResultActions perform = mockMvc.perform(post("/logs")
+        .contentType(MediaType.APPLICATION_JSON)
+        .header("app_id", appId)
+        .content(objectMapper.writeValueAsString(요청_DTO)));
+
+    // then
+    perform.andExpect(status().isBadRequest());
+  }
+
+  private static Stream<Arguments> invalidLogCreationInputs() {
+    return Stream.of(
+        Arguments.of("어플리케이션_ID가 음수인 경우", -1L, "INFO", "테스트_로그_데이터",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+        Arguments.of("로그_레벨이 null인 경우", 1L, null, "테스트_로그_데이터",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+        Arguments.of("로그_레벨이 빈 문자열인 경우", 1L, "  ", "테스트_로그_데이터",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+        Arguments.of("로그_데이터가 null인 경우", 1L, "INFO", null,
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+        Arguments.of("로그_데이터가 빈 문자열인 경우", 1L, "INFO", "  ",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+        Arguments.of("타임스탬프가 null인 경우", 1L, "INFO", "테스트_로그_데이터", null)
+    );
+  }
+}


### PR DESCRIPTION
## 🚀 개발 사항

1. Log 저장 기능 구현
  - LogRepository 생성자 변경 (AllArgsConstructor → RequiredArgsConstructor)
  - CreateLogServiceRequest 레코드 추가

2. LogService 구현 (Log 생성 및 저장 기능)
  - LogService 단위 테스트 추가

3. Controller 구현
  - CreateLogRequest DTO 추가 (validation 포함)
  - CreateLogServiceRequest로 변환하는 정적 팩토리 메서드 구현
  - LogController 구현 (applicationId 및 CreateLogRequest validation 포함)
  - LogController 단위 테스트 추가


4. 테스트 환경 구성
  - ControllerTestSupport 추가로 Controller 테스트 환경 통합


기타

build.gradle에 validation 의존성 추가
CreateLogRequest를 레코드로 변경

### 이슈 번호

- close #31 

## 특이 사항 🫶 
- aee7b3141: Controller Test 환경 통합용 `ControllerTestSuport`를 만들어 두었습니다.