### PR TITLE
Feat/#18 App 도메인 모델 구현

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/project/domain/App.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/App.java
@@ -1,0 +1,54 @@
+package info.logbat.domain.project.domain;
+
+import info.logbat.domain.project.domain.enums.AppType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SoftDelete;
+
+@Entity
+@Getter
+@Table(name = "entities")
+@SoftDelete
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class App {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "app_type", nullable = false)
+    private AppType appType;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    private App(Project project, AppType appType) {
+        this.project = Objects.requireNonNull(project, "프로젝트는 필수입니다.");
+        this.appType = Objects.requireNonNull(appType, "앱 타입은 필수입니다.");
+    }
+
+    public static App of(Project project, AppType appType) {
+        return new App(project, appType);
+    }
+
+}

--- a/logbat/src/main/java/info/logbat/domain/project/domain/enums/AppType.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/enums/AppType.java
@@ -1,0 +1,14 @@
+package info.logbat.domain.project.domain.enums;
+
+public enum AppType {
+    JS, JAVA;
+
+    public static AppType from(String appTypeName) {
+        for (AppType appType : AppType.values()) {
+            if (appType.name().equals(appTypeName)) {
+                return appType;
+            }
+        }
+        throw new IllegalArgumentException("잘못된 앱 타입 요청입니다.");
+    }
+}

--- a/logbat/src/test/java/info/logbat/domain/project/domain/AppTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/AppTest.java
@@ -1,0 +1,55 @@
+package info.logbat.domain.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import info.logbat.domain.project.domain.enums.AppType;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("App 도메인은")
+class AppTest {
+
+    @Nested
+    @DisplayName("생성 시")
+    class whenCreated {
+
+        private static final Project EXPECTED_PROJECT = Project.from("프로젝트");
+
+        @Test
+        @DisplayName("정상적으로 생성된다.")
+        void createSuccess() {
+            // Arrange
+            AppType expectedAppType = AppType.JS;
+            // Act
+            App actualResult = App.of(EXPECTED_PROJECT, expectedAppType);
+            // Assert
+            assertThat(actualResult)
+                .isNotNull()
+                .extracting("project", "appType")
+                .containsExactly(EXPECTED_PROJECT, expectedAppType);
+        }
+
+        @ParameterizedTest
+        @MethodSource("exceptionProvider")
+        @DisplayName("인자가 없으면 예외가 발생한다.")
+        void createFail(Project project, AppType appType, String expectedMessage) {
+            // Act & Assert
+            assertThatThrownBy(() -> App.of(project, appType))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage(expectedMessage);
+        }
+
+        private static Stream<Arguments> exceptionProvider() {
+            return Stream.of(
+                Arguments.of(null, AppType.JS, "프로젝트는 필수입니다."),
+                Arguments.of(EXPECTED_PROJECT, null, "앱 타입은 필수입니다.")
+            );
+        }
+    }
+}

--- a/logbat/src/test/java/info/logbat/domain/project/domain/enums/AppTypeTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/enums/AppTypeTest.java
@@ -1,0 +1,46 @@
+package info.logbat.domain.project.domain.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("AppType Enum은")
+class AppTypeTest {
+
+    @ParameterizedTest
+    @MethodSource("nameProvider")
+    @DisplayName("이름으로 Enum을 찾을 수 있다.")
+    void findEnumByName(String name, AppType expectedResult) {
+        // Act
+        AppType actualResult = AppType.from(name);
+        // Assert
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    @DisplayName("잘못된 이름으로 Enum을 찾을 경우 예외를 발생시킨다.")
+    void throwExceptionWhenFindEnumByInvalidName(String name) {
+        // Act & Assert
+        assertThatThrownBy(() -> AppType.from(name))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("잘못된 앱 타입 요청입니다.");
+    }
+
+    private static Stream<Arguments> nameProvider() {
+        return Stream.of(
+            Arguments.of("JS", AppType.JS),
+            Arguments.of("JAVA", AppType.JAVA)
+        );
+    }
+
+    private static Stream<String> exceptionProvider() {
+        return Stream.of("INVALID", "C++", "PYTHON", null);
+    }
+
+}


### PR DESCRIPTION
## 🚀 개발 사항

- App 도메인 엔티티를 구현했습니다.

| 필드 | 설명 |
|---|---|
| id | DB PK |
| project | 프로젝트 |
| appType | 앱 타입(JS, JAVA)|
| created_at | 생성 일자 |

- Hibernate 활용 Soft Deletion 을 적용했습니다. 

### 이슈 번호

- close #18 

## 특이 사항 🫶 

- 추가가 필요할 것 같은 필드 있으면 이유랑 함께 적어주세요 :D
