### PR TITLE
Feat/#19 App Key 생성 및 서비스 구현

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -9,8 +9,10 @@ import info.logbat.domain.project.repository.ProjectJpaRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class AppService {
 
@@ -24,6 +26,7 @@ public class AppService {
         return AppCommonResponse.from(appRepository.save(App.of(project, appType)));
     }
 
+    @Transactional(readOnly = true)
     public AppCommonResponse getAppByToken(String token) {
         UUID tokenUUID = UUID.fromString(token);
         App app = appRepository.findByToken(tokenUUID)
@@ -31,6 +34,7 @@ public class AppService {
         return AppCommonResponse.from(app);
     }
 
+    @Transactional(readOnly = true)
     public AppCommonResponse getAppById(Long id) {
         App app = appRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException(APP_NOT_FOUND_MESSAGE));

--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -6,6 +6,7 @@ import info.logbat.domain.project.domain.enums.AppType;
 import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
 import info.logbat.domain.project.repository.AppJpaRepository;
 import info.logbat.domain.project.repository.ProjectJpaRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,18 @@ public class AppService {
         return AppCommonResponse.from(appRepository.save(App.of(project, appType)));
     }
 
+    public AppCommonResponse getAppByToken(String token) {
+        UUID tokenUUID = UUID.fromString(token);
+        App app = appRepository.findByToken(tokenUUID)
+            .orElseThrow(() -> new IllegalArgumentException("앱을 찾을 수 없습니다."));
+        return AppCommonResponse.from(app);
+    }
+
+    public AppCommonResponse getAppById(Long id) {
+        App app = appRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("앱을 찾을 수 없습니다."));
+        return AppCommonResponse.from(app);
+    }
 
     private Project getProject(Long id) {
         return projectRepository.findById(id)

--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -1,0 +1,29 @@
+package info.logbat.domain.project.application;
+
+import info.logbat.domain.project.domain.App;
+import info.logbat.domain.project.domain.Project;
+import info.logbat.domain.project.domain.enums.AppType;
+import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
+import info.logbat.domain.project.repository.AppJpaRepository;
+import info.logbat.domain.project.repository.ProjectJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppService {
+
+    private final AppJpaRepository appRepository;
+    private final ProjectJpaRepository projectRepository;
+
+    public AppCommonResponse createApp(Long projectId, AppType appType) {
+        Project project = getProject(projectId);
+        return AppCommonResponse.from(appRepository.save(App.of(project, appType)));
+    }
+
+
+    private Project getProject(Long id) {
+        return projectRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+    }
+}

--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AppService {
 
+    private static final String APP_NOT_FOUND_MESSAGE = "앱을 찾을 수 없습니다.";
+
     private final AppJpaRepository appRepository;
     private final ProjectJpaRepository projectRepository;
 
@@ -25,14 +27,21 @@ public class AppService {
     public AppCommonResponse getAppByToken(String token) {
         UUID tokenUUID = UUID.fromString(token);
         App app = appRepository.findByToken(tokenUUID)
-            .orElseThrow(() -> new IllegalArgumentException("앱을 찾을 수 없습니다."));
+            .orElseThrow(() -> new IllegalArgumentException(APP_NOT_FOUND_MESSAGE));
         return AppCommonResponse.from(app);
     }
 
     public AppCommonResponse getAppById(Long id) {
         App app = appRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("앱을 찾을 수 없습니다."));
+            .orElseThrow(() -> new IllegalArgumentException(APP_NOT_FOUND_MESSAGE));
         return AppCommonResponse.from(app);
+    }
+
+    public Long deleteApp(Long projectId, Long appId) {
+        App app = appRepository.findByProject_IdAndId(projectId, appId)
+            .orElseThrow(() -> new IllegalArgumentException(APP_NOT_FOUND_MESSAGE));
+        appRepository.delete(app);
+        return app.getId();
     }
 
     private Project getProject(Long id) {

--- a/logbat/src/main/java/info/logbat/domain/project/domain/App.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/App.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,13 +39,18 @@ public class App {
     @Column(name = "app_type", nullable = false)
     private AppType appType;
 
+    @Column(name = "token", nullable = false, unique = true)
+    private UUID token;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+
     private App(Project project, AppType appType) {
         this.project = Objects.requireNonNull(project, "프로젝트는 필수입니다.");
         this.appType = Objects.requireNonNull(appType, "앱 타입은 필수입니다.");
+        this.token = UUID.randomUUID();
     }
 
     public static App of(Project project, AppType appType) {

--- a/logbat/src/main/java/info/logbat/domain/project/domain/App.java
+++ b/logbat/src/main/java/info/logbat/domain/project/domain/App.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,9 @@ import org.hibernate.annotations.SoftDelete;
 
 @Entity
 @Getter
-@Table(name = "entities")
+@Table(name = "entities", indexes = {
+    @Index(name = "idx_app_token", columnList = "token")
+})
 @SoftDelete
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class App {

--- a/logbat/src/main/java/info/logbat/domain/project/presentation/payload/response/AppCommonResponse.java
+++ b/logbat/src/main/java/info/logbat/domain/project/presentation/payload/response/AppCommonResponse.java
@@ -1,0 +1,13 @@
+package info.logbat.domain.project.presentation.payload.response;
+
+import info.logbat.domain.project.domain.App;
+import java.time.LocalDateTime;
+
+public record AppCommonResponse(Long id, Long projectId, String appType, String token,
+                                LocalDateTime createdAt) {
+
+    public static AppCommonResponse from(App app) {
+        return new AppCommonResponse(app.getId(), app.getProject().getId(), app.getAppType().name(),
+            app.getToken().toString(), app.getCreatedAt());
+    }
+}

--- a/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
@@ -1,10 +1,14 @@
 package info.logbat.domain.project.repository;
 
 import info.logbat.domain.project.domain.App;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AppJpaRepository extends JpaRepository<App, Long> {
 
+    Optional<App> findByToken(@NonNull UUID token);
 }

--- a/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface AppJpaRepository extends JpaRepository<App, Long> {
 
     Optional<App> findByToken(@NonNull UUID token);
+
+    Optional<App> findByProject_IdAndId(@NonNull Long id, @NonNull Long id1);
 }

--- a/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
@@ -1,0 +1,10 @@
+package info.logbat.domain.project.repository;
+
+import info.logbat.domain.project.domain.App;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppJpaRepository extends JpaRepository<App, Long> {
+
+}

--- a/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
@@ -1,0 +1,86 @@
+package info.logbat.domain.project.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import info.logbat.domain.project.domain.App;
+import info.logbat.domain.project.domain.Project;
+import info.logbat.domain.project.domain.enums.AppType;
+import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
+import info.logbat.domain.project.repository.AppJpaRepository;
+import info.logbat.domain.project.repository.ProjectJpaRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AppService는")
+class AppServiceTest {
+
+    @InjectMocks
+    private AppService appService;
+
+    @Mock
+    private AppJpaRepository appRepository;
+    @Mock
+    private ProjectJpaRepository projectRepository;
+
+    private final Project expectedProject = mock(Project.class);
+    private final App expectedApp = spy(App.of(expectedProject, AppType.JAVA));
+    private final Long expectedProjectId = 1L;
+
+    @Nested
+    @DisplayName("새로운 App을 생성할 때")
+    class whenCreateNewApp {
+
+        @Test
+        @DisplayName("프로젝트가 존재하지 않으면 IllegalArgumentException을 던진다.")
+        void willThrowExceptionWhenProjectNotFound() {
+            // Arrange
+            Long notExistProjectId = 2L;
+            given(projectRepository.findById(notExistProjectId)).willReturn(Optional.empty());
+            // Act & Assert
+            assertThatThrownBy(() -> appService.createApp(notExistProjectId, AppType.JAVA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("프로젝트를 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("정상적으로 생성한다.")
+        void willCreateNewApp() {
+            // Arrange
+            Long expectedAppId = 1L;
+            LocalDateTime expectedCreatedAt = LocalDateTime.now();
+            given(projectRepository.findById(expectedProjectId)).willReturn(
+                Optional.of(expectedProject));
+            given(expectedProject.getId()).willReturn(expectedProjectId);
+            given(appRepository.save(any(App.class))).willReturn(expectedApp);
+            given(expectedApp.getId()).willReturn(expectedAppId);
+            given(expectedApp.getCreatedAt()).willReturn(expectedCreatedAt);
+            // Act
+            AppCommonResponse actualResult = appService.createApp(expectedProjectId, AppType.JAVA);
+            // Assert
+            assertAll(
+                () -> assertThat(actualResult)
+                    .extracting("id", "projectId", "appType", "createdAt")
+                    .containsExactly(expectedAppId, expectedProjectId, AppType.JAVA.name(),
+                        expectedCreatedAt),
+                () -> assertThat(actualResult.token()).isNotNull()
+            );
+
+        }
+
+    }
+
+}

--- a/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
@@ -145,4 +145,34 @@ class AppServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("App을 삭제할 때")
+    class whenDeleteApp {
+
+        @Test
+        @DisplayName("프로젝트와 앱 ID로 삭제할 수 있다.")
+        void canDeleteAppByProjectIdAndAppId() {
+            // Arrange
+            given(appRepository.findByProject_IdAndId(expectedProjectId, expectedAppId)).willReturn(
+                Optional.of(expectedApp));
+            given(expectedApp.getId()).willReturn(expectedAppId);
+            // Act
+            Long actualResult = appService.deleteApp(expectedProjectId, expectedAppId);
+            // Assert
+            assertThat(actualResult).isEqualTo(expectedAppId);
+        }
+
+        @Test
+        @DisplayName("앱을 찾을 수 없으면 예외를 던진다.")
+        void willThrowExceptionWhenAppNotFound() {
+            // Arrange
+            given(appRepository.findByProject_IdAndId(expectedProjectId, expectedAppId)).willReturn(
+                Optional.empty());
+            // Act & Assert
+            assertThatThrownBy(() -> appService.deleteApp(expectedProjectId, expectedAppId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("앱을 찾을 수 없습니다.");
+        }
+    }
+
 }

--- a/logbat/src/test/java/info/logbat/domain/project/domain/AppTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/domain/AppTest.java
@@ -2,6 +2,7 @@ package info.logbat.domain.project.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import info.logbat.domain.project.domain.enums.AppType;
 import java.util.stream.Stream;
@@ -29,10 +30,13 @@ class AppTest {
             // Act
             App actualResult = App.of(EXPECTED_PROJECT, expectedAppType);
             // Assert
-            assertThat(actualResult)
-                .isNotNull()
-                .extracting("project", "appType")
-                .containsExactly(EXPECTED_PROJECT, expectedAppType);
+            assertAll(
+                () -> assertThat(actualResult)
+                    .isNotNull()
+                    .extracting("project", "appType")
+                    .containsExactly(EXPECTED_PROJECT, expectedAppType),
+                () -> assertThat(actualResult.getToken()).isNotNull()
+            );
         }
 
         @ParameterizedTest


### PR DESCRIPTION
## 🚀 개발 사항
- App 조회 로직 구현 (서비스 레이어)
  - Token을 활용한 App 조회 기능 추가
  - ID를 활용한 App 조회 기능 추가
- App 생성 로직 구현 (서비스 레이어)
  - App 생성 및 DB 저장 후 결과 반환 기능 추가
  - `AppCommonResponse` DTO를 통한 결과 반환
- App token 기능 추가
  - App 생성 시 UUID 기반 토큰 생성 기능 구현

### 이슈 번호
- close #19
- close #41 

## 특이 사항 🫶 