### PR TITLE
Feat/#48 App API 구현

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -6,6 +6,7 @@ import info.logbat.domain.project.domain.enums.AppType;
 import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
 import info.logbat.domain.project.repository.AppJpaRepository;
 import info.logbat.domain.project.repository.ProjectJpaRepository;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,12 @@ public class AppService {
         App app = appRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException(APP_NOT_FOUND_MESSAGE));
         return AppCommonResponse.from(app);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AppCommonResponse> getAppsByProjectId(Long projectId) {
+        List<App> apps = appRepository.findByProject_Id(projectId);
+        return apps.stream().map(AppCommonResponse::from).toList();
     }
 
     public Long deleteApp(Long projectId, Long appId) {

--- a/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
+++ b/logbat/src/main/java/info/logbat/domain/project/application/AppService.java
@@ -22,8 +22,9 @@ public class AppService {
     private final AppJpaRepository appRepository;
     private final ProjectJpaRepository projectRepository;
 
-    public AppCommonResponse createApp(Long projectId, AppType appType) {
+    public AppCommonResponse createApp(Long projectId, String appTypeStr) {
         Project project = getProject(projectId);
+        AppType appType = AppType.from(appTypeStr);
         return AppCommonResponse.from(appRepository.save(App.of(project, appType)));
     }
 

--- a/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
+++ b/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
@@ -2,11 +2,14 @@ package info.logbat.domain.project.presentation;
 
 import info.logbat.common.payload.ApiCommonResponse;
 import info.logbat.domain.project.application.AppService;
+import info.logbat.domain.project.presentation.payload.request.AppCreateRequest;
 import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,5 +31,11 @@ public class AppController {
         return ApiCommonResponse.createSuccessResponse(appService.getAppById(id));
     }
 
+    @PostMapping
+    public ApiCommonResponse<AppCommonResponse> createApp(
+        @RequestBody AppCreateRequest appCreateRequest) {
+        return ApiCommonResponse.createSuccessResponse(
+            appService.createApp(appCreateRequest.projectId(), appCreateRequest.appType()));
+    }
 
 }

--- a/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
+++ b/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
@@ -6,6 +6,7 @@ import info.logbat.domain.project.presentation.payload.request.AppCreateRequest;
 import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,6 +37,12 @@ public class AppController {
         @RequestBody AppCreateRequest appCreateRequest) {
         return ApiCommonResponse.createSuccessResponse(
             appService.createApp(appCreateRequest.projectId(), appCreateRequest.appType()));
+    }
+
+    @DeleteMapping("/{projectId}/{appId}")
+    public ApiCommonResponse<Long> deleteApp(@PathVariable Long projectId,
+        @PathVariable Long appId) {
+        return ApiCommonResponse.createSuccessResponse(appService.deleteApp(projectId, appId));
     }
 
 }

--- a/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
+++ b/logbat/src/main/java/info/logbat/domain/project/presentation/AppController.java
@@ -1,0 +1,32 @@
+package info.logbat.domain.project.presentation;
+
+import info.logbat.common.payload.ApiCommonResponse;
+import info.logbat.domain.project.application.AppService;
+import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/projects/apps")
+@RequiredArgsConstructor
+public class AppController {
+
+    private final AppService appService;
+
+    @GetMapping("/{projectId}")
+    public ApiCommonResponse<List<AppCommonResponse>> getAppsByProjectId(
+        @PathVariable Long projectId) {
+        return ApiCommonResponse.createSuccessResponse(appService.getAppsByProjectId(projectId));
+    }
+
+    @GetMapping("/info/{id}")
+    public ApiCommonResponse<AppCommonResponse> getAppById(@PathVariable Long id) {
+        return ApiCommonResponse.createSuccessResponse(appService.getAppById(id));
+    }
+
+
+}

--- a/logbat/src/main/java/info/logbat/domain/project/presentation/payload/request/AppCreateRequest.java
+++ b/logbat/src/main/java/info/logbat/domain/project/presentation/payload/request/AppCreateRequest.java
@@ -1,0 +1,5 @@
+package info.logbat.domain.project.presentation.payload.request;
+
+public record AppCreateRequest(Long projectId, String appType) {
+
+}

--- a/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/project/repository/AppJpaRepository.java
@@ -1,6 +1,7 @@
 package info.logbat.domain.project.repository;
 
 import info.logbat.domain.project.domain.App;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface AppJpaRepository extends JpaRepository<App, Long> {
     Optional<App> findByToken(@NonNull UUID token);
 
     Optional<App> findByProject_IdAndId(@NonNull Long id, @NonNull Long id1);
+
+    List<App> findByProject_Id(@NonNull Long id);
 }

--- a/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
+++ b/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
@@ -3,7 +3,9 @@ package info.logbat.domain.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.logbat.domain.log.application.LogService;
 import info.logbat.domain.log.presentation.LogController;
+import info.logbat.domain.project.application.AppService;
 import info.logbat.domain.project.application.ProjectService;
+import info.logbat.domain.project.presentation.AppController;
 import info.logbat.domain.project.presentation.ProjectController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -14,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 /*
  * 이후 테스트 하려면 Controller에 대해 controllers에 추가하고, ControllerTestSupport를 상속받아 테스트를 진행하시면 됩니다.
  */
-@WebMvcTest(controllers = {LogController.class, ProjectController.class})
+@WebMvcTest(controllers = {LogController.class, ProjectController.class, AppController.class})
 @ActiveProfiles("test")
 public abstract class ControllerTestSupport {
 
@@ -29,6 +31,9 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected ProjectService projectService;
+
+    @MockBean
+    protected AppService appService;
 
     /*
      * 이후 필요한 서비스에 대해 MockBean을 추가하여 테스트를 진행하시면 됩니다.

--- a/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
@@ -47,6 +47,8 @@ class AppServiceTest {
     @DisplayName("새로운 App을 생성할 때")
     class whenCreateNewApp {
 
+        private final String expectedAppType = AppType.JAVA.name();
+
         @Test
         @DisplayName("프로젝트가 존재하지 않으면 IllegalArgumentException을 던진다.")
         void willThrowExceptionWhenProjectNotFound() {
@@ -54,9 +56,22 @@ class AppServiceTest {
             Long notExistProjectId = 2L;
             given(projectRepository.findById(notExistProjectId)).willReturn(Optional.empty());
             // Act & Assert
-            assertThatThrownBy(() -> appService.createApp(notExistProjectId, AppType.JAVA))
+            assertThatThrownBy(() -> appService.createApp(notExistProjectId, expectedAppType))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("프로젝트를 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("AppType이 잘못된 경우 IllegalArgumentException을 던진다.")
+        void willThrowExceptionWhenAppTypeIsInvalid() {
+            // Arrange
+            String invalidAppType = "INVALID";
+            given(projectRepository.findById(expectedProjectId)).willReturn(
+                Optional.of(expectedProject));
+            // Act & Assert
+            assertThatThrownBy(() -> appService.createApp(expectedProjectId, invalidAppType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 앱 타입 요청입니다.");
         }
 
         @Test
@@ -71,12 +86,13 @@ class AppServiceTest {
             given(expectedApp.getId()).willReturn(expectedAppId);
             given(expectedApp.getCreatedAt()).willReturn(expectedCreatedAt);
             // Act
-            AppCommonResponse actualResult = appService.createApp(expectedProjectId, AppType.JAVA);
+            AppCommonResponse actualResult = appService.createApp(expectedProjectId,
+                expectedAppType);
             // Assert
             assertAll(
                 () -> assertThat(actualResult)
                     .extracting("id", "projectId", "appType", "createdAt")
-                    .containsExactly(expectedAppId, expectedProjectId, AppType.JAVA.name(),
+                    .containsExactly(expectedAppId, expectedProjectId, expectedAppType,
                         expectedCreatedAt),
                 () -> assertThat(actualResult.token()).isNotNull()
             );

--- a/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/application/AppServiceTest.java
@@ -15,6 +15,7 @@ import info.logbat.domain.project.presentation.payload.response.AppCommonRespons
 import info.logbat.domain.project.repository.AppJpaRepository;
 import info.logbat.domain.project.repository.ProjectJpaRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -118,6 +119,19 @@ class AppServiceTest {
             assertThat(actualResult)
                 .extracting("id")
                 .isEqualTo(expectedAppId);
+        }
+
+        @Test
+        @DisplayName("Project Id로 Apps를 조회할 수 있다.")
+        void canGetAppsByProjectId() {
+            // Arrange
+            given(appRepository.findByProject_Id(expectedProjectId)).willReturn(
+                List.of(expectedApp));
+            given(expectedApp.getId()).willReturn(expectedAppId);
+            // Act
+            List<AppCommonResponse> actualResult = appService.getAppsByProjectId(expectedProjectId);
+            // Assert
+            assertThat(actualResult).hasSize(1);
         }
 
         @Test

--- a/logbat/src/test/java/info/logbat/domain/project/presentation/AppControllerTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/presentation/AppControllerTest.java
@@ -2,6 +2,7 @@ package info.logbat.domain.project.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -113,6 +114,27 @@ class AppControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.appType").value(expectedAppType.name()))
                 .andExpect(jsonPath("$.data.token").value(expectedToken.toString()))
                 .andExpect(jsonPath("$.data.createdAt").value(expectedCreatedAt.toString()));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("DELETE에 대해")
+    class describeDeleteApp {
+
+        @Test
+        @DisplayName("/v1/projects/apps/{projectId}/{appId} 요청시 프로젝트 ID와 앱 ID로 앱을 삭제할 수 있다.")
+        void willDeleteApp() throws Exception {
+            // Arrange
+            given(appService.deleteApp(expectedProjectId, expectedId)).willReturn(expectedId);
+            MockHttpServletRequestBuilder delete = delete("/v1/projects/apps/{projectId}/{appId}",
+                expectedProjectId, expectedId);
+            // Act & Assert
+            mockMvc.perform(delete)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("Success"))
+                .andExpect(jsonPath("$.data").value(expectedId));
         }
 
     }

--- a/logbat/src/test/java/info/logbat/domain/project/presentation/AppControllerTest.java
+++ b/logbat/src/test/java/info/logbat/domain/project/presentation/AppControllerTest.java
@@ -1,0 +1,87 @@
+package info.logbat.domain.project.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import info.logbat.domain.common.ControllerTestSupport;
+import info.logbat.domain.project.domain.enums.AppType;
+import info.logbat.domain.project.presentation.payload.response.AppCommonResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AppController는")
+class AppControllerTest extends ControllerTestSupport {
+
+    @Nested
+    @DisplayName("GET에 대해")
+    class describeGetApps {
+
+        private final AppCommonResponse expectedAppCommonResponse = mock(AppCommonResponse.class);
+        private final Long expectedId = 1L;
+        private final Long expectedProjectId = 1L;
+        private final AppType expectedAppType = AppType.JAVA;
+        private final UUID expectedToken = UUID.randomUUID();
+        private final LocalDateTime expectedCreatedAt = LocalDateTime.now();
+
+        @BeforeEach
+        void init() {
+            given(expectedAppCommonResponse.id()).willReturn(expectedId);
+            given(expectedAppCommonResponse.projectId()).willReturn(expectedProjectId);
+            given(expectedAppCommonResponse.appType()).willReturn(expectedAppType.name());
+            given(expectedAppCommonResponse.token()).willReturn(expectedToken.toString());
+            given(expectedAppCommonResponse.createdAt()).willReturn(expectedCreatedAt);
+        }
+
+        @Test
+        @DisplayName("/v1/projects/apps/{projectId} 요청시 프로젝트 ID로 앱 목록을 조회할 수 있다.")
+        void willReturnAppList() throws Exception {
+            // Arrange
+            given(appService.getAppsByProjectId(expectedProjectId)).willReturn(
+                List.of(expectedAppCommonResponse));
+            MockHttpServletRequestBuilder get = get("/v1/projects/apps/{projectId}",
+                expectedProjectId);
+            // Act & Assert
+            mockMvc.perform(get)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("Success"))
+                .andExpect(jsonPath("$.data[0].id").value(expectedId))
+                .andExpect(jsonPath("$.data[0].projectId").value(expectedProjectId))
+                .andExpect(jsonPath("$.data[0].appType").value(expectedAppType.name()))
+                .andExpect(jsonPath("$.data[0].token").value(expectedToken.toString()))
+                .andExpect(jsonPath("$.data[0].createdAt").value(expectedCreatedAt.toString()));
+        }
+
+        @Test
+        @DisplayName("/v1/projects/apps/info/{id} 요청시 앱 ID로 앱 정보를 조회할 수 있다.")
+        void willReturnAppInformation() throws Exception {
+            // Arrange
+            given(appService.getAppById(expectedId)).willReturn(expectedAppCommonResponse);
+            MockHttpServletRequestBuilder get = get("/v1/projects/apps/info/{id}", expectedId);
+            // Act & Assert
+            mockMvc.perform(get)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("Success"))
+                .andExpect(jsonPath("$.data.id").value(expectedId))
+                .andExpect(jsonPath("$.data.projectId").value(expectedProjectId))
+                .andExpect(jsonPath("$.data.appType").value(expectedAppType.name()))
+                .andExpect(jsonPath("$.data.token").value(expectedToken.toString()))
+                .andExpect(jsonPath("$.data.createdAt").value(expectedCreatedAt.toString()));
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🚀 작업 내용
이 PR은 `AppController`의 API 엔드포인트에 대한 문서화를 추가합니다. 각 엔드포인트에 대한 설명, 요청/응답 형식, 그리고 예시를 포함합니다.

## 📸 이슈 번호
- close #48 

## API 문서화 상세 내용

### 1. GET /v1/projects/apps/{projectId}
프로젝트 ID에 해당하는 모든 앱 정보를 조회합니다.

**요청 파라미터:**
- `projectId` (path variable): 조회할 프로젝트의 ID

**응답:**
```json
{
  "statusCode": 200,
  "message": "Success",
  "data": [
    {
      "id": 1,
      "projectId": 1,
      "appType": "WEB",
      "token": "abc123...",
      "createdAt": "2024-08-14T10:30:00"
    },
    ...
  ]
}
```

### 2. GET /v1/projects/apps/info/{id}
특정 앱의 상세 정보를 조회합니다.

**요청 파라미터:**
- `id` (path variable): 조회할 앱의 ID

**응답:**
```json
{
  "statusCode": 200,
  "message": "Success",
  "data": {
    "id": 1,
    "projectId": 1,
    "appType": "WEB",
    "token": "abc123...",
    "createdAt": "2024-08-14T10:30:00"
  }
}
```

### 3. POST /v1/projects/apps
새로운 앱을 생성합니다.

**요청 본문:**
```json
{
  "projectId": 1,
  "appType": "WEB"
}
```

**응답:**
```json
{
  "statusCode": 200,
  "message": "Success",
  "data": {
    "id": 2,
    "projectId": 1,
    "appType": "WEB",
    "token": "xyz789...",
    "createdAt": "2024-08-14T11:00:00"
  }
}
```

### 4. DELETE /v1/projects/apps/{projectId}/{appId}
특정 프로젝트의 앱을 삭제합니다.

**요청 파라미터:**
- `projectId` (path variable): 앱이 속한 프로젝트의 ID
- `appId` (path variable): 삭제할 앱의 ID

**응답:**
```json
{
  "statusCode": 200,
  "message": "Success",
  "data": 2  // 삭제된 앱의 ID
}
```

## ✍ 궁금한 점
- API 문서화의 상세도가 적절한지 검토 부탁드립니다.
- 각 엔드포인트의 설명이 명확한지 확인 부탁드립니다.
- 요청/응답 예시가 충분한지, 혹은 추가적인 예시가 필요한지 의견 주시면 감사하겠습니다.
- 에러 응답에 대한 문서화도 필요할지 고민 중입니다. 의견 주시면 감사하겠습니다.