### PR TITLE
Feat/#54 요청 처리 수를 확인하는 API 추가

### DIFF
--- a/logbat/src/main/java/info/logbat/dev/aop/CountTest.java
+++ b/logbat/src/main/java/info/logbat/dev/aop/CountTest.java
@@ -1,0 +1,12 @@
+package info.logbat.dev.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CountTest {
+
+}

--- a/logbat/src/main/java/info/logbat/dev/aop/CountTestAspect.java
+++ b/logbat/src/main/java/info/logbat/dev/aop/CountTestAspect.java
@@ -1,0 +1,35 @@
+package info.logbat.dev.aop;
+
+import info.logbat.dev.service.CountTestService;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CountTestAspect {
+
+  private final CountTestService countTestService;
+
+  @Pointcut("@annotation(info.logbat.dev.aop.CountTest)")
+  public void countTestPointcut() {
+  }
+
+  @Around("countTestPointcut()")
+  public Object countTest(ProceedingJoinPoint joinPoint) throws Throwable {
+    try {
+      Object proceed = joinPoint.proceed();
+      countTestService.increaseSuccessCount();
+
+      return proceed;
+    } catch (Throwable e) {
+      countTestService.increaseErrorCount();
+      throw e;
+    }
+  }
+
+}

--- a/logbat/src/main/java/info/logbat/dev/presentation/CountTestController.java
+++ b/logbat/src/main/java/info/logbat/dev/presentation/CountTestController.java
@@ -1,0 +1,34 @@
+package info.logbat.dev.presentation;
+
+import info.logbat.common.payload.ApiCommonResponse;
+import info.logbat.dev.presentation.payload.response.CountTestResponse;
+import info.logbat.dev.service.CountTestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test/count")
+@RequiredArgsConstructor
+public class CountTestController {
+
+  private final CountTestService countTestService;
+
+  @GetMapping
+  public ApiCommonResponse<CountTestResponse> count() {
+
+    return ApiCommonResponse.createSuccessResponse(
+        CountTestResponse.of(countTestService.getSuccessCount(), countTestService.getErrorCount()));
+  }
+
+  @PutMapping("/reset")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void reset() {
+    countTestService.reset();
+  }
+
+}

--- a/logbat/src/main/java/info/logbat/dev/presentation/payload/response/CountTestResponse.java
+++ b/logbat/src/main/java/info/logbat/dev/presentation/payload/response/CountTestResponse.java
@@ -1,0 +1,11 @@
+package info.logbat.dev.presentation.payload.response;
+
+public record CountTestResponse(
+    Long successCount,
+    Long errorCount
+) {
+
+  public static CountTestResponse of(Long successCount, Long errorCount) {
+    return new CountTestResponse(successCount, errorCount);
+  }
+}

--- a/logbat/src/main/java/info/logbat/dev/service/CountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/CountTestService.java
@@ -1,36 +1,14 @@
 package info.logbat.dev.service;
 
-import java.util.concurrent.atomic.AtomicLong;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
+public interface CountTestService {
 
-@Component
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CountTestService {
+  void increaseSuccessCount();
 
-  private final AtomicLong successCount = new AtomicLong(0L);
-  private final AtomicLong errorCount = new AtomicLong(0L);
+  void increaseErrorCount();
 
-  public void increaseSuccessCount() {
-    successCount.incrementAndGet();
-  }
+  long getSuccessCount();
 
-  public void increaseErrorCount() {
-    errorCount.incrementAndGet();
-  }
+  long getErrorCount();
 
-  public long getSuccessCount() {
-    return successCount.get();
-  }
-
-  public long getErrorCount() {
-    return errorCount.get();
-  }
-
-  public void reset() {
-    successCount.set(0L);
-    errorCount.set(0L);
-  }
-
+  void reset();
 }

--- a/logbat/src/main/java/info/logbat/dev/service/CountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/CountTestService.java
@@ -1,0 +1,36 @@
+package info.logbat.dev.service;
+
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CountTestService {
+
+  private final AtomicLong successCount = new AtomicLong(0L);
+  private final AtomicLong errorCount = new AtomicLong(0L);
+
+  public void increaseSuccessCount() {
+    successCount.incrementAndGet();
+  }
+
+  public void increaseErrorCount() {
+    errorCount.incrementAndGet();
+  }
+
+  public long getSuccessCount() {
+    return successCount.get();
+  }
+
+  public long getErrorCount() {
+    return errorCount.get();
+  }
+
+  public void reset() {
+    successCount.set(0L);
+    errorCount.set(0L);
+  }
+
+}

--- a/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
@@ -1,8 +1,6 @@
 package info.logbat.dev.service;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import info.logbat.dev.util.ThreadLocalLongAdder;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -10,100 +8,33 @@ import org.springframework.stereotype.Component;
 @Component
 public class DivideCountTestService implements CountTestService {
 
-  private final ThreadLocal<Counter> localCounter = ThreadLocal.withInitial(Counter::new);
+  private final ThreadLocalLongAdder successCount = new ThreadLocalLongAdder();
+  private final ThreadLocalLongAdder errorCount = new ThreadLocalLongAdder();
 
-  private final AtomicLong successCount = new AtomicLong(0L);
-  private final AtomicLong errorCount = new AtomicLong(0L);
-
-  // ThreadLocal -> Counter 인스턴스
-  //                  ^
-  //                 /
-  // Map.get(Thread)
-
-  // Key가 Thread.currentThread()이기 때문에 경쟁상태가 발생하지 않음
-  private final Map<Thread, Counter> activeThreads = new HashMap<>(150);
-
+  @Override
   public void increaseSuccessCount() {
-    Counter counter = localCounter.get();
-
-    // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
-    counter.increaseSuccessCount();
-    activeThreads.putIfAbsent(Thread.currentThread(), counter);
+    successCount.increment();
   }
 
+  @Override
   public void increaseErrorCount() {
-    Counter counter = localCounter.get();
-
-    // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
-    counter.increaseErrorCount();
-    activeThreads.putIfAbsent(Thread.currentThread(), counter);
+    errorCount.increment();
   }
 
+  @Override
   public long getSuccessCount() {
-    flushAllThreadLocals();
     return successCount.get();
   }
 
+  @Override
   public long getErrorCount() {
-    flushAllThreadLocals();
     return errorCount.get();
   }
 
+  @Override
   public void reset() {
-    resetAllThreadLocals();
-    successCount.set(0L);
-    errorCount.set(0L);
-  }
-
-  // 중복 집계되는 경우를 방지하기 위해, flush 시 Counter 객체에 대해서 동기화 처리
-  private void flushAllThreadLocals() {
-    synchronized (activeThreads) {
-      activeThreads.values().forEach(counter -> {
-        successCount.addAndGet(counter.getSuccessCount());
-        errorCount.addAndGet(counter.getErrorCount());
-        counter.resetIncreaseCount();
-        counter.resetErrorCount();
-      });
-    }
-  }
-
-  private void resetAllThreadLocals() {
-    activeThreads.values().forEach(counter -> {
-      counter.resetIncreaseCount();
-      counter.resetErrorCount();
-    });
-
-    activeThreads.clear();
-  }
-
-  static class Counter {
-
-    private long successCount;
-    private long errorCount;
-
-    public void increaseSuccessCount() {
-      successCount++;
-    }
-
-    public void increaseErrorCount() {
-      errorCount++;
-    }
-
-    public long getSuccessCount() {
-      return successCount;
-    }
-
-    public long getErrorCount() {
-      return errorCount;
-    }
-
-    public void resetIncreaseCount() {
-      successCount = 0L;
-    }
-
-    public void resetErrorCount() {
-      errorCount = 0L;
-    }
-
+    successCount.reset();
+    errorCount.reset();
   }
 }
+

--- a/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
@@ -1,10 +1,8 @@
 package info.logbat.dev.service;
 
 import info.logbat.dev.util.ThreadLocalLongAdder;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-@Primary
 @Component
 public class DivideCountTestService implements CountTestService {
 

--- a/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
@@ -3,14 +3,11 @@ package info.logbat.dev.service;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DivideCountTestService implements CountTestService {
 
   private final ThreadLocal<Counter> localCounter = ThreadLocal.withInitial(Counter::new);

--- a/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
@@ -1,0 +1,124 @@
+package info.logbat.dev.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DivideCountTestService implements CountTestService {
+
+  private final ThreadLocal<Counter> localCounter = ThreadLocal.withInitial(Counter::new);
+
+  private static final Long BUFFER_SIZE = 1000L;
+
+  private final AtomicLong successCount = new AtomicLong(0L);
+  private final AtomicLong errorCount = new AtomicLong(0L);
+
+  // ThreadLocal -> Counter 인스턴스
+  //                  ^
+  //                 /
+  // Map.get(Thread)
+
+  // Key가 Thread.currentThread()이기 때문에 경쟁상태가 발생하지 않음
+  private final Map<Thread, Counter> activeThreads = new HashMap<>(150);
+
+  public void increaseSuccessCount() {
+    Counter counter = localCounter.get();
+
+    // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
+    counter.increaseSuccessCount();
+    activeThreads.putIfAbsent(Thread.currentThread(), counter);
+
+    if (counter.getSuccessCount() >= BUFFER_SIZE) {
+      successCount.addAndGet(counter.getSuccessCount());
+      counter.resetIncreaseCount();
+    }
+  }
+
+  public void increaseErrorCount() {
+    Counter counter = localCounter.get();
+
+    // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
+    counter.increaseErrorCount();
+    activeThreads.putIfAbsent(Thread.currentThread(), counter);
+
+    if (counter.getErrorCount() >= BUFFER_SIZE) {
+      errorCount.addAndGet(counter.getErrorCount());
+      counter.resetErrorCount();
+    }
+  }
+
+  public long getSuccessCount() {
+    flushAllThreadLocals();
+    return successCount.get();
+  }
+
+  public long getErrorCount() {
+    flushAllThreadLocals();
+    return errorCount.get();
+  }
+
+  public void reset() {
+    resetAllThreadLocals();
+    successCount.set(0L);
+    errorCount.set(0L);
+  }
+
+  // 중복 집계되는 경우를 방지하기 위해, flush 시 Counter 객체에 대해서 동기화 처리
+  private void flushAllThreadLocals() {
+    activeThreads.values().forEach(counter -> {
+      synchronized (counter) {
+        successCount.addAndGet(counter.getSuccessCount());
+        errorCount.addAndGet(counter.getErrorCount());
+        counter.resetIncreaseCount();
+        counter.resetErrorCount();
+      }
+    });
+  }
+
+  private void resetAllThreadLocals() {
+    activeThreads.values().forEach(counter -> {
+      counter.resetIncreaseCount();
+      counter.resetErrorCount();
+    });
+
+    activeThreads.clear();
+  }
+
+  static class Counter {
+
+    private long successCount;
+    private long errorCount;
+
+    public void increaseSuccessCount() {
+      successCount++;
+    }
+
+    public void increaseErrorCount() {
+      errorCount++;
+    }
+
+    public long getSuccessCount() {
+      return successCount;
+    }
+
+    public long getErrorCount() {
+      return errorCount;
+    }
+
+    public void resetIncreaseCount() {
+      successCount = 0L;
+    }
+
+    public void resetErrorCount() {
+      errorCount = 0L;
+    }
+
+  }
+}

--- a/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/DivideCountTestService.java
@@ -59,13 +59,15 @@ public class DivideCountTestService implements CountTestService {
   }
 
   // 중복 집계되는 경우를 방지하기 위해, flush 시 Counter 객체에 대해서 동기화 처리
-  private synchronized void flushAllThreadLocals() {
-    activeThreads.values().forEach(counter -> {
-      successCount.addAndGet(counter.getSuccessCount());
-      errorCount.addAndGet(counter.getErrorCount());
-      counter.resetIncreaseCount();
-      counter.resetErrorCount();
-    });
+  private void flushAllThreadLocals() {
+    synchronized (activeThreads) {
+      activeThreads.values().forEach(counter -> {
+        successCount.addAndGet(counter.getSuccessCount());
+        errorCount.addAndGet(counter.getErrorCount());
+        counter.resetIncreaseCount();
+        counter.resetErrorCount();
+      });
+    }
   }
 
   private void resetAllThreadLocals() {

--- a/logbat/src/main/java/info/logbat/dev/service/LongAdderCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/LongAdderCountTestService.java
@@ -1,0 +1,38 @@
+package info.logbat.dev.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.LongAdder;
+
+@Component
+public class LongAdderCountTestService implements CountTestService {
+
+  private final LongAdder successCount = new LongAdder();
+  private final LongAdder errorCount = new LongAdder();
+
+  @Override
+  public void increaseSuccessCount() {
+    successCount.increment();
+  }
+
+  @Override
+  public void increaseErrorCount() {
+    errorCount.increment();
+  }
+
+  @Override
+  public long getSuccessCount() {
+    return successCount.sum();
+  }
+
+  @Override
+  public long getErrorCount() {
+    return errorCount.sum();
+  }
+
+  @Override
+  public void reset() {
+    successCount.reset();
+    errorCount.reset();
+  }
+}

--- a/logbat/src/main/java/info/logbat/dev/service/LongAdderCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/LongAdderCountTestService.java
@@ -1,9 +1,10 @@
 package info.logbat.dev.service;
 
+import java.util.concurrent.atomic.LongAdder;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.atomic.LongAdder;
-
+@Primary
 @Component
 public class LongAdderCountTestService implements CountTestService {
 

--- a/logbat/src/main/java/info/logbat/dev/service/SimpleCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/SimpleCountTestService.java
@@ -1,0 +1,40 @@
+package info.logbat.dev.service;
+
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleCountTestService implements CountTestService {
+
+  private final AtomicLong successCount = new AtomicLong(0L);
+  private final AtomicLong errorCount = new AtomicLong(0L);
+
+  @Override
+  public void increaseSuccessCount() {
+    successCount.incrementAndGet();
+  }
+
+  @Override
+  public void increaseErrorCount() {
+    errorCount.incrementAndGet();
+  }
+
+  @Override
+  public long getSuccessCount() {
+    return successCount.get();
+  }
+
+  @Override
+  public long getErrorCount() {
+    return errorCount.get();
+  }
+
+  @Override
+  public void reset() {
+    successCount.set(0L);
+    errorCount.set(0L);
+  }
+}

--- a/logbat/src/main/java/info/logbat/dev/service/SimpleCountTestService.java
+++ b/logbat/src/main/java/info/logbat/dev/service/SimpleCountTestService.java
@@ -1,12 +1,9 @@
 package info.logbat.dev.service;
 
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SimpleCountTestService implements CountTestService {
 
   private final AtomicLong successCount = new AtomicLong(0L);

--- a/logbat/src/main/java/info/logbat/dev/util/ThreadLocalLongAdder.java
+++ b/logbat/src/main/java/info/logbat/dev/util/ThreadLocalLongAdder.java
@@ -1,0 +1,71 @@
+package info.logbat.dev.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ThreadLocalLongAdder {
+
+  private final ThreadLocal<Counter> localCounter = new ThreadLocal<>();
+
+  /**
+   * ConcurrentHashMap을 사용해야하는 이유
+   * <p>
+   * 두 Thread가 같은 hashCode를 가지고 동시에 새 Counter를 추가하려 할 때, 한 Thread의 Counter가 다른 Thread의 Counter로 덮어쓰일
+   * 가능성이 있습니다.
+   */
+  private final Map<Thread, Counter> activeCounters = new ConcurrentHashMap<>(200);
+  private long value = 0L;
+
+  public void increment() {
+    Counter counter = localCounter.get();
+
+    // Thread 내의 Counter가 없으면, 새로운 Counter를 생성하여 ThreadLocal과 activeCounters에 추가
+    if (counter == null) {
+      counter = new Counter();
+      localCounter.set(counter);
+      activeCounters.put(Thread.currentThread(), counter);
+    }
+
+    // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
+    counter.increaseValue();
+  }
+
+  public long get() {
+    flush();
+    return value;
+  }
+
+  // reset 시에도 activeCounters를 유지하여 reset 후에도 추적 가능함
+  public void reset() {
+    flush();
+    value = 0L;
+  }
+
+  private void flush() {
+    synchronized (activeCounters) {
+      for (Counter counter : activeCounters.values()) {
+        value += counter.getValue();
+        counter.resetValue();
+      }
+    }
+  }
+
+
+  private static class Counter {
+
+    private long value;
+
+    public void increaseValue() {
+      value++;
+    }
+
+    public long getValue() {
+      return value;
+    }
+
+    public void resetValue() {
+      value = 0;
+    }
+
+  }
+}

--- a/logbat/src/main/java/info/logbat/dev/util/ThreadLocalLongAdder.java
+++ b/logbat/src/main/java/info/logbat/dev/util/ThreadLocalLongAdder.java
@@ -1,29 +1,25 @@
 package info.logbat.dev.util;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.lang.ref.WeakReference;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class ThreadLocalLongAdder {
 
   private final ThreadLocal<Counter> localCounter = new ThreadLocal<>();
+  private final Queue<WeakReference<Counter>> activeCounters = new ConcurrentLinkedQueue<>();
 
-  /**
-   * ConcurrentHashMap을 사용해야하는 이유
-   * <p>
-   * 두 Thread가 같은 hashCode를 가지고 동시에 새 Counter를 추가하려 할 때, 한 Thread의 Counter가 다른 Thread의 Counter로 덮어쓰일
-   * 가능성이 있습니다.
-   */
-  private final Map<Thread, Counter> activeCounters = new ConcurrentHashMap<>(200);
   private long value = 0L;
 
   public void increment() {
     Counter counter = localCounter.get();
 
     // Thread 내의 Counter가 없으면, 새로운 Counter를 생성하여 ThreadLocal과 activeCounters에 추가
+    // WeakReference를 사용하여 GC가 Counter를 수거할 수 있도록 함
     if (counter == null) {
       counter = new Counter();
       localCounter.set(counter);
-      activeCounters.put(Thread.currentThread(), counter);
+      activeCounters.add(new WeakReference<>(counter));
     }
 
     // Thread 내의 Counter에 증가연산을 수행하여, 경쟁상태가 발생하지 않음
@@ -43,10 +39,15 @@ public class ThreadLocalLongAdder {
 
   private void flush() {
     synchronized (activeCounters) {
-      for (Counter counter : activeCounters.values()) {
-        value += counter.getValue();
+      activeCounters.removeIf(weakCounter -> {
+        Counter counter = weakCounter.get();
+        if (counter == null) {
+          return true; // Thread가 제거되어 WeakReference가 null을 가리키면 해당 엔트리 제거
+        }
+        value += (counter.getValue());
         counter.resetValue();
-      }
+        return false;
+      });
     }
   }
 

--- a/logbat/src/main/java/info/logbat/domain/log/presentation/LogController.java
+++ b/logbat/src/main/java/info/logbat/domain/log/presentation/LogController.java
@@ -1,5 +1,6 @@
 package info.logbat.domain.log.presentation;
 
+import info.logbat.dev.aop.CountTest;
 import info.logbat.domain.log.application.LogService;
 import info.logbat.domain.log.application.payload.request.CreateLogServiceRequest;
 import info.logbat.domain.log.presentation.payload.request.CreateLogRequest;
@@ -21,6 +22,7 @@ public class LogController {
 
   private final LogService logService;
 
+  @CountTest
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public void saveLog(

--- a/logbat/src/test/java/info/logbat/dev/presentation/CountTestControllerTest.java
+++ b/logbat/src/test/java/info/logbat/dev/presentation/CountTestControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.http.MediaType;
 @DisplayName("카운트 조회 API 테스트")
 class CountTestControllerTest extends ControllerTestSupport {
 
-  @DisplayName("카운트 조회 API 테스트")
+  @DisplayName("[GET] /test/count 성공")
   @Test
   void testGetCount() throws Exception {
     when(countTestService.getSuccessCount()).thenReturn(10L);
@@ -32,7 +32,7 @@ class CountTestControllerTest extends ControllerTestSupport {
   }
 
   @Test
-  @DisplayName("카운트 리셋 API 테스트")
+  @DisplayName("[PUT] /test/count/reset reset api 호출 성공")
   void testResetCount() throws Exception {
     mockMvc.perform(put("/test/count/reset")
             .contentType(MediaType.APPLICATION_JSON))

--- a/logbat/src/test/java/info/logbat/dev/presentation/CountTestControllerTest.java
+++ b/logbat/src/test/java/info/logbat/dev/presentation/CountTestControllerTest.java
@@ -1,0 +1,43 @@
+package info.logbat.dev.presentation;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import info.logbat.domain.common.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+@DisplayName("카운트 조회 API 테스트")
+class CountTestControllerTest extends ControllerTestSupport {
+
+  @DisplayName("카운트 조회 API 테스트")
+  @Test
+  void testGetCount() throws Exception {
+    when(countTestService.getSuccessCount()).thenReturn(10L);
+    when(countTestService.getErrorCount()).thenReturn(5L);
+
+    mockMvc.perform(get("/test/count")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.successCount").value(10))
+        .andExpect(jsonPath("$.data.errorCount").value(5));
+
+    verify(countTestService).getSuccessCount();
+    verify(countTestService).getErrorCount();
+  }
+
+  @Test
+  @DisplayName("카운트 리셋 API 테스트")
+  void testResetCount() throws Exception {
+    mockMvc.perform(put("/test/count/reset")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(countTestService).reset();
+  }
+}

--- a/logbat/src/test/java/info/logbat/dev/service/CountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/CountTestServiceTest.java
@@ -1,0 +1,113 @@
+package info.logbat.dev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("CountTestService 테스트")
+class CountTestServiceTest {
+
+  @AfterEach
+  void tearDown() {
+    countTestService.reset();
+  }
+
+  @Autowired
+  private CountTestService countTestService;
+
+  @Nested
+  @DisplayName("성공 카운트 테스트")
+  class SuccessCountTest {
+
+    @Test
+    @DisplayName("성공 카운트 증가")
+    void testIncreaseSuccessCount() {
+      // given
+      long 예상_성공_카운트 = countTestService.getSuccessCount() + 1;
+
+      // when
+      countTestService.increaseSuccessCount();
+
+      // then
+      assertThat(countTestService.getSuccessCount()).isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("성공 카운트 여러 번 증가")
+    void testMultipleIncreaseSuccessCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_성공_카운트 = countTestService.getSuccessCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        countTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(countTestService.getSuccessCount())
+          .isEqualTo(예상_성공_카운트);
+    }
+  }
+
+  @Nested
+  @DisplayName("오류 카운트 테스트")
+  class ErrorCountTest {
+
+    @Test
+    @DisplayName("오류 카운트 증가")
+    void testIncreaseErrorCount() {
+      // given
+      long 예상_에러_카운트 = countTestService.getErrorCount() + 1;
+
+      // when
+      countTestService.increaseErrorCount();
+
+      // then
+      assertThat(countTestService.getErrorCount())
+          .isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("오류 카운트 여러 번 증가")
+    void testMultipleIncreaseErrorCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_에러_카운트 = countTestService.getErrorCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        countTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(countTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+  }
+
+  @Test
+  @DisplayName("카운트 초기화")
+  void testReset() {
+    // given
+    countTestService.increaseSuccessCount();
+    countTestService.increaseErrorCount();
+
+    // when
+    countTestService.reset();
+
+    // then
+    assertAll(
+        () -> assertThat(countTestService.getSuccessCount()).isZero(),
+        () -> assertThat(countTestService.getErrorCount()).isZero()
+    );
+  }
+}

--- a/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
@@ -122,20 +122,6 @@ class DivideCountTestServiceTest {
       assertThat(totalSuccessCount).isEqualTo(6);
     }
 
-    @Test
-    @DisplayName("정상 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
-    void flushesToMainCounterWhenBufferIsFull() {
-      // given
-      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
-
-      // when
-      for (int i = 0; i < bufferSize; i++) {
-        divideCountTestService.increaseSuccessCount();
-      }
-
-      // then
-      assertThat(divideCountTestService.getSuccessCount()).isEqualTo(bufferSize);
-    }
   }
 
   @Nested
@@ -191,21 +177,6 @@ class DivideCountTestServiceTest {
 
       // then
       assertThat(totalErrorCount).isEqualTo(6);
-    }
-
-    @DisplayName("오류 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
-    @Test
-    void flushesToMainCounterWhenBufferIsFull() {
-      // given
-      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
-
-      // when
-      for (int i = 0; i < bufferSize; i++) {
-        divideCountTestService.increaseErrorCount();
-      }
-
-      // then
-      assertThat(divideCountTestService.getErrorCount()).isEqualTo(bufferSize);
     }
   }
 

--- a/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
@@ -1,0 +1,229 @@
+package info.logbat.dev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("CountTestService 테스트")
+class DivideCountTestServiceTest {
+
+  @Autowired
+  private DivideCountTestService divideCountTestService;
+
+  @AfterEach
+  void tearDown() {
+    divideCountTestService.getSuccessCount();
+    divideCountTestService.getErrorCount();
+    divideCountTestService.reset();
+  }
+
+  @DisplayName("여러 스레드에서 카운트를 증가해도 동기화가 보장된다.")
+  @Test
+  @Disabled("도메인 로직과 관련 없는 테스트이므로 평소에는 비활성화")
+  void testParallelIncrement() throws InterruptedException {
+    long threadCount = 100;
+    long incrementsPerThread = 1000000;
+
+    ExecutorService executorService = Executors.newFixedThreadPool((int) threadCount);
+
+    List<Callable<Void>> tasks = new ArrayList<>((int) threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      tasks.add(() -> {
+        for (int j = 0; j < incrementsPerThread; j++) {
+          divideCountTestService.increaseSuccessCount();
+          divideCountTestService.increaseErrorCount();
+        }
+        return null;
+      });
+    }
+
+    executorService.invokeAll(tasks);
+    executorService.shutdown();
+
+    long successCount = divideCountTestService.getSuccessCount();
+    long errorCount = divideCountTestService.getErrorCount();
+
+    assertAll(
+        () -> assertThat(successCount).isEqualTo(threadCount * incrementsPerThread),
+        () -> assertThat(errorCount).isEqualTo(threadCount * incrementsPerThread)
+    );
+    divideCountTestService.reset();
+  }
+
+
+  @Nested
+  @DisplayName("성공 카운트 테스트")
+  class SuccessCountTest {
+
+    @Test
+    @DisplayName("성공 카운트 증가")
+    void testIncreaseSuccessCount() {
+      // given
+      long 예상_성공_카운트 = divideCountTestService.getSuccessCount() + 1;
+
+      // when
+      divideCountTestService.increaseSuccessCount();
+
+      // then
+      assertThat(divideCountTestService.getSuccessCount()).isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("성공 카운트 여러 번 증가")
+    void testMultipleIncreaseSuccessCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_성공_카운트 = divideCountTestService.getSuccessCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        divideCountTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(divideCountTestService.getSuccessCount())
+          .isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("모든 스레드의 성공 카운트를 합산하여 반환한다")
+    void returnsSumOfAllThreadsSuccessCount() throws InterruptedException {
+      // given
+      divideCountTestService.increaseSuccessCount();
+      // 다른 스레드에서의 증가를 시뮬레이션
+      Thread thread = new Thread(() -> {
+        for (int i = 0; i < 5; i++) {
+          divideCountTestService.increaseSuccessCount();
+        }
+      });
+      thread.start();
+
+      thread.join();
+
+      // when
+      long totalSuccessCount = divideCountTestService.getSuccessCount();
+
+      // then
+      assertThat(totalSuccessCount).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("정상 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
+    void flushesToMainCounterWhenBufferIsFull() {
+      // given
+      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
+
+      // when
+      for (int i = 0; i < bufferSize; i++) {
+        divideCountTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(divideCountTestService.getSuccessCount()).isEqualTo(bufferSize);
+    }
+  }
+
+  @Nested
+  @DisplayName("오류 카운트 테스트")
+  class ErrorCountTest {
+
+    @Test
+    @DisplayName("오류 카운트 증가")
+    void testIncreaseErrorCount() {
+      // given
+      long 예상_에러_카운트 = divideCountTestService.getErrorCount() + 1;
+
+      // when
+      divideCountTestService.increaseErrorCount();
+
+      // then
+      assertThat(divideCountTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("오류 카운트 여러 번 증가")
+    void testMultipleIncreaseErrorCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_에러_카운트 = divideCountTestService.getErrorCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        divideCountTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(divideCountTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("모든 스레드의 에러 카운트를 합산하여 반환한다")
+    void returnsSumOfAllThreadsErrorCount() throws InterruptedException {
+      // given
+      divideCountTestService.increaseErrorCount();
+
+      Thread thread = new Thread(() -> {
+        for (int i = 0; i < 5; i++) {
+          divideCountTestService.increaseErrorCount();
+        }
+      });
+      thread.start();
+
+      thread.join();
+
+      // when
+      long totalErrorCount = divideCountTestService.getErrorCount();
+
+      // then
+      assertThat(totalErrorCount).isEqualTo(6);
+    }
+
+    @DisplayName("오류 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
+    @Test
+    void flushesToMainCounterWhenBufferIsFull() {
+      // given
+      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
+
+      // when
+      for (int i = 0; i < bufferSize; i++) {
+        divideCountTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(divideCountTestService.getErrorCount()).isEqualTo(bufferSize);
+    }
+  }
+
+  @Test
+  @DisplayName("카운트 초기화")
+  void testReset() {
+    // given
+    divideCountTestService.increaseSuccessCount();
+    divideCountTestService.increaseErrorCount();
+
+    // when
+    divideCountTestService.reset();
+
+    // then
+    assertAll(
+        () -> assertThat(divideCountTestService.getSuccessCount()).isZero(),
+        () -> assertThat(divideCountTestService.getErrorCount()).isZero()
+    );
+  }
+
+}

--- a/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
@@ -13,17 +13,13 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("DivideCountTestService 테스트")
 class DivideCountTestServiceTest {
 
-  @Autowired
-  private DivideCountTestService divideCountTestService;
+  private DivideCountTestService divideCountTestService = new DivideCountTestService();
 
   @AfterEach
   void tearDown() {

--- a/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@DisplayName("CountTestService 테스트")
+@DisplayName("DivideCountTestService 테스트")
 class DivideCountTestServiceTest {
 
   @Autowired

--- a/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/DivideCountTestServiceTest.java
@@ -32,7 +32,7 @@ class DivideCountTestServiceTest {
   @Test
   @Disabled("도메인 로직과 관련 없는 테스트이므로 평소에는 비활성화")
   void testParallelIncrement() throws InterruptedException {
-    long threadCount = 100;
+    long threadCount = 1000;
     long incrementsPerThread = 1000000;
 
     ExecutorService executorService = Executors.newFixedThreadPool((int) threadCount);
@@ -42,7 +42,6 @@ class DivideCountTestServiceTest {
       tasks.add(() -> {
         for (int j = 0; j < incrementsPerThread; j++) {
           divideCountTestService.increaseSuccessCount();
-          divideCountTestService.increaseErrorCount();
         }
         return null;
       });
@@ -52,13 +51,7 @@ class DivideCountTestServiceTest {
     executorService.shutdown();
 
     long successCount = divideCountTestService.getSuccessCount();
-    long errorCount = divideCountTestService.getErrorCount();
-
-    assertAll(
-        () -> assertThat(successCount).isEqualTo(threadCount * incrementsPerThread),
-        () -> assertThat(errorCount).isEqualTo(threadCount * incrementsPerThread)
-    );
-    divideCountTestService.reset();
+    assertThat(successCount).isEqualTo(threadCount * incrementsPerThread);
   }
 
 

--- a/logbat/src/test/java/info/logbat/dev/service/LongAdderCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/LongAdderCountTestServiceTest.java
@@ -1,18 +1,19 @@
 package info.logbat.dev.service;
 
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @DisplayName("LongAdderCountTestServiceTest 테스트")
@@ -31,7 +32,7 @@ class LongAdderCountTestServiceTest {
   @Test
   @Disabled("도메인 로직과 관련 없는 테스트이므로 평소에는 비활성화")
   void testParallelIncrement() throws InterruptedException {
-    long threadCount = 100;
+    long threadCount = 1000;
     long incrementsPerThread = 1000000;
 
     ExecutorService executorService = Executors.newFixedThreadPool((int) threadCount);
@@ -41,7 +42,6 @@ class LongAdderCountTestServiceTest {
       tasks.add(() -> {
         for (int j = 0; j < incrementsPerThread; j++) {
           longAdderCountTestService.increaseSuccessCount();
-          longAdderCountTestService.increaseErrorCount();
         }
         return null;
       });
@@ -51,13 +51,8 @@ class LongAdderCountTestServiceTest {
     executorService.shutdown();
 
     long successCount = longAdderCountTestService.getSuccessCount();
-    long errorCount = longAdderCountTestService.getErrorCount();
 
-    assertAll(
-        () -> assertThat(successCount).isEqualTo(threadCount * incrementsPerThread),
-        () -> assertThat(errorCount).isEqualTo(threadCount * incrementsPerThread)
-    );
-    longAdderCountTestService.reset();
+    assertThat(successCount).isEqualTo(threadCount * incrementsPerThread);
   }
 
 

--- a/logbat/src/test/java/info/logbat/dev/service/LongAdderCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/LongAdderCountTestServiceTest.java
@@ -1,0 +1,224 @@
+package info.logbat.dev.service;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ActiveProfiles("test")
+@DisplayName("LongAdderCountTestServiceTest 테스트")
+class LongAdderCountTestServiceTest {
+
+  private LongAdderCountTestService longAdderCountTestService = new LongAdderCountTestService();
+
+  @AfterEach
+  void tearDown() {
+    longAdderCountTestService.getSuccessCount();
+    longAdderCountTestService.getErrorCount();
+    longAdderCountTestService.reset();
+  }
+
+  @DisplayName("여러 스레드에서 카운트를 증가해도 동기화가 보장된다.")
+  @Test
+  @Disabled("도메인 로직과 관련 없는 테스트이므로 평소에는 비활성화")
+  void testParallelIncrement() throws InterruptedException {
+    long threadCount = 100;
+    long incrementsPerThread = 1000000;
+
+    ExecutorService executorService = Executors.newFixedThreadPool((int) threadCount);
+
+    List<Callable<Void>> tasks = new ArrayList<>((int) threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      tasks.add(() -> {
+        for (int j = 0; j < incrementsPerThread; j++) {
+          longAdderCountTestService.increaseSuccessCount();
+          longAdderCountTestService.increaseErrorCount();
+        }
+        return null;
+      });
+    }
+
+    executorService.invokeAll(tasks);
+    executorService.shutdown();
+
+    long successCount = longAdderCountTestService.getSuccessCount();
+    long errorCount = longAdderCountTestService.getErrorCount();
+
+    assertAll(
+        () -> assertThat(successCount).isEqualTo(threadCount * incrementsPerThread),
+        () -> assertThat(errorCount).isEqualTo(threadCount * incrementsPerThread)
+    );
+    longAdderCountTestService.reset();
+  }
+
+
+  @Nested
+  @DisplayName("성공 카운트 테스트")
+  class SuccessCountTest {
+
+    @Test
+    @DisplayName("성공 카운트 증가")
+    void testIncreaseSuccessCount() {
+      // given
+      long 예상_성공_카운트 = longAdderCountTestService.getSuccessCount() + 1;
+
+      // when
+      longAdderCountTestService.increaseSuccessCount();
+
+      // then
+      assertThat(longAdderCountTestService.getSuccessCount()).isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("성공 카운트 여러 번 증가")
+    void testMultipleIncreaseSuccessCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_성공_카운트 = longAdderCountTestService.getSuccessCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        longAdderCountTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(longAdderCountTestService.getSuccessCount())
+          .isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("모든 스레드의 성공 카운트를 합산하여 반환한다")
+    void returnsSumOfAllThreadsSuccessCount() throws InterruptedException {
+      // given
+      longAdderCountTestService.increaseSuccessCount();
+      // 다른 스레드에서의 증가를 시뮬레이션
+      Thread thread = new Thread(() -> {
+        for (int i = 0; i < 5; i++) {
+          longAdderCountTestService.increaseSuccessCount();
+        }
+      });
+      thread.start();
+
+      thread.join();
+
+      // when
+      long totalSuccessCount = longAdderCountTestService.getSuccessCount();
+
+      // then
+      assertThat(totalSuccessCount).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("정상 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
+    void flushesToMainCounterWhenBufferIsFull() {
+      // given
+      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
+
+      // when
+      for (int i = 0; i < bufferSize; i++) {
+        longAdderCountTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(longAdderCountTestService.getSuccessCount()).isEqualTo(bufferSize);
+    }
+  }
+
+  @Nested
+  @DisplayName("오류 카운트 테스트")
+  class ErrorCountTest {
+
+    @Test
+    @DisplayName("오류 카운트 증가")
+    void testIncreaseErrorCount() {
+      // given
+      long 예상_에러_카운트 = longAdderCountTestService.getErrorCount() + 1;
+
+      // when
+      longAdderCountTestService.increaseErrorCount();
+
+      // then
+      assertThat(longAdderCountTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("오류 카운트 여러 번 증가")
+    void testMultipleIncreaseErrorCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_에러_카운트 = longAdderCountTestService.getErrorCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        longAdderCountTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(longAdderCountTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("모든 스레드의 에러 카운트를 합산하여 반환한다")
+    void returnsSumOfAllThreadsErrorCount() throws InterruptedException {
+      // given
+      longAdderCountTestService.increaseErrorCount();
+
+      Thread thread = new Thread(() -> {
+        for (int i = 0; i < 5; i++) {
+          longAdderCountTestService.increaseErrorCount();
+        }
+      });
+      thread.start();
+
+      thread.join();
+
+      // when
+      long totalErrorCount = longAdderCountTestService.getErrorCount();
+
+      // then
+      assertThat(totalErrorCount).isEqualTo(6);
+    }
+
+    @DisplayName("오류 버퍼 크기에 도달하더라도 메인 카운터에 반영된다")
+    @Test
+    void flushesToMainCounterWhenBufferIsFull() {
+      // given
+      long bufferSize = 1000L; // BUFFER_SIZE와 동일한 값
+
+      // when
+      for (int i = 0; i < bufferSize; i++) {
+        longAdderCountTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(longAdderCountTestService.getErrorCount()).isEqualTo(bufferSize);
+    }
+  }
+
+  @Test
+  @DisplayName("카운트 초기화")
+  void testReset() {
+    // given
+    longAdderCountTestService.increaseSuccessCount();
+    longAdderCountTestService.increaseErrorCount();
+
+    // when
+    longAdderCountTestService.reset();
+
+    // then
+    assertAll(
+        () -> assertThat(longAdderCountTestService.getSuccessCount()).isZero(),
+        () -> assertThat(longAdderCountTestService.getErrorCount()).isZero()
+    );
+  }
+
+}

--- a/logbat/src/test/java/info/logbat/dev/service/SimpleCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/SimpleCountTestServiceTest.java
@@ -7,11 +7,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("SimpleCountTestService 테스트")
 class SimpleCountTestServiceTest {
@@ -21,8 +18,7 @@ class SimpleCountTestServiceTest {
     simpleCountTestService.reset();
   }
 
-  @Autowired
-  private SimpleCountTestService simpleCountTestService;
+  private SimpleCountTestService simpleCountTestService = new SimpleCountTestService();
 
   @Nested
   @DisplayName("성공 카운트 테스트")

--- a/logbat/src/test/java/info/logbat/dev/service/SimpleCountTestServiceTest.java
+++ b/logbat/src/test/java/info/logbat/dev/service/SimpleCountTestServiceTest.java
@@ -1,0 +1,113 @@
+package info.logbat.dev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("SimpleCountTestService 테스트")
+class SimpleCountTestServiceTest {
+
+  @AfterEach
+  void tearDown() {
+    simpleCountTestService.reset();
+  }
+
+  @Autowired
+  private SimpleCountTestService simpleCountTestService;
+
+  @Nested
+  @DisplayName("성공 카운트 테스트")
+  class SuccessCountTest {
+
+    @Test
+    @DisplayName("성공 카운트 증가")
+    void testIncreaseSuccessCount() {
+      // given
+      long 예상_성공_카운트 = simpleCountTestService.getSuccessCount() + 1;
+
+      // when
+      simpleCountTestService.increaseSuccessCount();
+
+      // then
+      assertThat(simpleCountTestService.getSuccessCount()).isEqualTo(예상_성공_카운트);
+    }
+
+    @Test
+    @DisplayName("성공 카운트 여러 번 증가")
+    void testMultipleIncreaseSuccessCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_성공_카운트 = simpleCountTestService.getSuccessCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        simpleCountTestService.increaseSuccessCount();
+      }
+
+      // then
+      assertThat(simpleCountTestService.getSuccessCount())
+          .isEqualTo(예상_성공_카운트);
+    }
+  }
+
+  @Nested
+  @DisplayName("오류 카운트 테스트")
+  class ErrorCountTest {
+
+    @Test
+    @DisplayName("오류 카운트 증가")
+    void testIncreaseErrorCount() {
+      // given
+      long 예상_에러_카운트 = simpleCountTestService.getErrorCount() + 1;
+
+      // when
+      simpleCountTestService.increaseErrorCount();
+
+      // then
+      assertThat(simpleCountTestService.getErrorCount())
+          .isEqualTo(예상_에러_카운트);
+    }
+
+    @Test
+    @DisplayName("오류 카운트 여러 번 증가")
+    void testMultipleIncreaseErrorCount() {
+      // given
+      int 증가_횟수 = 5;
+      long 예상_에러_카운트 = simpleCountTestService.getErrorCount() + 증가_횟수;
+
+      // when
+      for (int i = 0; i < 증가_횟수; i++) {
+        simpleCountTestService.increaseErrorCount();
+      }
+
+      // then
+      assertThat(simpleCountTestService.getErrorCount()).isEqualTo(예상_에러_카운트);
+    }
+  }
+
+  @Test
+  @DisplayName("카운트 초기화")
+  void testReset() {
+    // given
+    simpleCountTestService.increaseSuccessCount();
+    simpleCountTestService.increaseErrorCount();
+
+    // when
+    simpleCountTestService.reset();
+
+    // then
+    assertAll(
+        () -> assertThat(simpleCountTestService.getSuccessCount()).isZero(),
+        () -> assertThat(simpleCountTestService.getErrorCount()).isZero()
+    );
+  }
+}

--- a/logbat/src/test/java/info/logbat/dev/util/ThreadLocalLongAdderTest.java
+++ b/logbat/src/test/java/info/logbat/dev/util/ThreadLocalLongAdderTest.java
@@ -1,0 +1,148 @@
+package info.logbat.dev.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ThreadLocalLongAdder 테스트")
+class ThreadLocalLongAdderTest {
+
+  private ThreadLocalLongAdder adder = new ThreadLocalLongAdder();
+
+  @AfterEach
+  void tearDown() {
+    adder.reset();
+  }
+
+  @Test
+  @DisplayName("초기값은 0이다")
+  void initialValueIsZero() {
+    assertThat(adder.get()).isZero();
+  }
+
+  @Nested
+  @DisplayName("increment 테스트")
+  class IncrementTest {
+
+    @Test
+    @DisplayName("increment 호출 시 값이 1 증가한다")
+    void incrementIncreasesValueByOne() {
+      // when
+      adder.increment();
+
+      // then
+      assertThat(adder.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여러 번 increment 호출 시 호출한 만큼 값이 증가한다")
+    void multipleIncrementsIncreaseValue() {
+      // when
+      int count = 5;
+      for (int i = 0; i < count; i++) {
+        adder.increment();
+      }
+
+      // then
+      assertThat(adder.get()).isEqualTo(count);
+    }
+  }
+
+  @Test
+  @DisplayName("reset 호출 시 값이 0으로 초기화된다")
+  void resetSetsValueToZero() {
+    // given
+    adder.increment();
+    assertThat(adder.get()).isNotZero();
+
+    // when
+    adder.reset();
+
+    // then
+    assertThat(adder.get()).isZero();
+  }
+
+  @Test
+  @DisplayName("두 개의 스레드에서 증가시킨 값의 합을 정확히 반환한다")
+  void returnsSumOfTwoThreads() throws InterruptedException {
+    // given
+    int incrementsPerThread = 10;
+
+    Thread thread1 = new Thread(() -> {
+      for (int i = 0; i < incrementsPerThread; i++) {
+        adder.increment();
+      }
+    });
+
+    Thread thread2 = new Thread(() -> {
+      for (int i = 0; i < incrementsPerThread; i++) {
+        adder.increment();
+      }
+    });
+
+    // when
+    thread1.start();
+    thread2.start();
+
+    thread1.join();
+    thread2.join();
+
+    long result = adder.get();
+
+    // then
+    assertThat(result).isEqualTo(incrementsPerThread * 2);
+  }
+
+  @Test
+  @Disabled("부하가 큰 테스트이므로 평소에는 비활성화")
+  @DisplayName("여러 스레드에서 동시에 증가시켜도 모든 스레드의 합을 정확히 반환한다")
+  void returnsSumOfMultipleThreads() throws InterruptedException {
+    int threadCount = 1000;
+    int incrementsPerThread = 10000000;
+
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+    List<Callable<Void>> tasks = new ArrayList<>(threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      tasks.add(() -> {
+        for (int j = 0; j < incrementsPerThread; j++) {
+          adder.increment();
+        }
+        return null;
+      });
+    }
+
+    executorService.invokeAll(tasks);
+    executorService.shutdown();
+
+    long result = adder.get();
+
+    assertThat(result).isEqualTo((long) threadCount * incrementsPerThread);
+  }
+
+  @Test
+  @DisplayName("reset 메소드는 누적 합계를 0으로 초기화한다")
+  void resetMethodClearsCumulativeSum() {
+    // given
+    adder.increment();
+    adder.get();  // 누적값 1
+    adder.increment();
+    adder.get();  // 누적값 3
+
+    // when
+    adder.reset();
+    long result = adder.get();
+
+    // then
+    assertThat(result).isZero();
+  }
+}

--- a/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
+++ b/logbat/src/test/java/info/logbat/domain/common/ControllerTestSupport.java
@@ -1,6 +1,8 @@
 package info.logbat.domain.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import info.logbat.dev.presentation.CountTestController;
+import info.logbat.dev.service.CountTestService;
 import info.logbat.domain.log.application.LogService;
 import info.logbat.domain.log.presentation.LogController;
 import info.logbat.domain.project.application.AppService;
@@ -16,27 +18,31 @@ import org.springframework.test.web.servlet.MockMvc;
 /*
  * 이후 테스트 하려면 Controller에 대해 controllers에 추가하고, ControllerTestSupport를 상속받아 테스트를 진행하시면 됩니다.
  */
-@WebMvcTest(controllers = {LogController.class, ProjectController.class, AppController.class})
+@WebMvcTest(controllers = {LogController.class, ProjectController.class, AppController.class,
+    CountTestController.class})
 @ActiveProfiles("test")
 public abstract class ControllerTestSupport {
 
-    @Autowired
-    protected MockMvc mockMvc;
+  @Autowired
+  protected MockMvc mockMvc;
 
-    @Autowired
-    protected ObjectMapper objectMapper;
+  @Autowired
+  protected ObjectMapper objectMapper;
 
-    @MockBean
-    protected LogService logService;
+  @MockBean
+  protected LogService logService;
 
-    @MockBean
-    protected ProjectService projectService;
+  @MockBean
+  protected ProjectService projectService;
 
-    @MockBean
-    protected AppService appService;
+  @MockBean
+  protected AppService appService;
 
-    /*
-     * 이후 필요한 서비스에 대해 MockBean을 추가하여 테스트를 진행하시면 됩니다.
-     */
+  @MockBean
+  protected CountTestService countTestService;
+
+  /*
+   * 이후 필요한 서비스에 대해 MockBean을 추가하여 테스트를 진행하시면 됩니다.
+   */
 
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 메서드 호출 횟수를 측정할 수 있는 CountTest 어노테이션을 만들었습니다.
- 여러 메서드 호출을 안전하게 카운팅할 수 있는 CountTestService를 구현했습니다.
- 구현된 카운트 기능이 올바르게 동작하는지 CountTestService 테스트를 작성했습니다.
- 다른 방식으로 카운팅을 확장할 수 있도록 인터페이스를 만들었습니다. (일반 AtomicLong, Thread별 카운팅 서비스)
- 어노테이션이 있는 메서드에 대해 카운팅이 이루어지도록 설정했습니다.

## 📸 이슈 번호

- close #54 

## 👀 Focus Commits [Optional]

- e2aa389: Count에 따른 서버 부하를 최소화하기 위해 Thread 내에 경쟁조건이 발생하지 않게 `DivideCountTestService`를 구현했습니다. 
ThreadLocal 내부의 값은 경쟁이 발생하지 않으므로 동기화문제로부터 자유롭고, 해당 값을 봐야할 때는 `flush`하는 메서드를 추가하여 구현했습니다. 

ThreadLocal을 사용할 Thread의 수가 한정되어 있고, 지속적으로 사용되어야하는 점으로 reset 시 ThreadLocal을 초기화하는 로직은 의도적으로 추가하지 않았습니다. 

위 부분에 대해 얼마나 성능적으로 향상되었는지 테스트로 검토가 반드시 필요합니다.

## ✍ 궁금한 점
- 중점적으로 봐줄 내용
- 변수명 괜찮나요
- 로직이 좀 더럽나요
- 가독성이 좀 그런가요?
