### PR TITLE
Feat/#81 로그 레벨 세분화

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/log/domain/Log.java
+++ b/logbat/src/main/java/info/logbat/domain/log/domain/Log.java
@@ -22,8 +22,19 @@ public class Log {
     this(null, appKey, level, data, timestamp);
   }
 
-  public Log(Long logId, String appKey, String level, String data,
+  public Log(Long logId, String appKey, Integer level, String data,
       LocalDateTime timestamp) {
+    this.logId = logId;
+    validateAppKey(appKey);
+    this.appKey = appKey;
+    this.level = Level.from(level);
+    this.data = LogData.from(data);
+    validateTimestamp(timestamp);
+    this.timestamp = timestamp;
+  }
+
+  public Log(Long logId, String appKey, String level, String data,
+             LocalDateTime timestamp) {
     this.logId = logId;
     validateAppKey(appKey);
     this.appKey = appKey;

--- a/logbat/src/main/java/info/logbat/domain/log/domain/enums/Level.java
+++ b/logbat/src/main/java/info/logbat/domain/log/domain/enums/Level.java
@@ -1,8 +1,12 @@
 package info.logbat.domain.log.domain.enums;
 
 public enum Level {
-  ERROR,
-  INFO;
+  TRACE, // 0
+  DEBUG, // 1
+  INFO, // 2
+  WARN, // 3
+  ERROR; // 4
+
 
   public static Level from(String level) {
     if (level == null || level.isBlank()) {
@@ -13,6 +17,20 @@ public enum Level {
 
     for (Level logLevel : Level.values()) {
       if (logLevel.name().equals(upperCaseLevel)) {
+        return logLevel;
+      }
+    }
+
+    throw new IllegalArgumentException("level이 올바르지 않습니다.");
+  }
+
+  public static Level from(Integer level) {
+    if (level == null) {
+      throw new IllegalArgumentException("level은 null이 될 수 없습니다.");
+    }
+
+    for (Level logLevel : Level.values()) {
+      if (logLevel.ordinal() == level) {
         return logLevel;
       }
     }

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -28,7 +28,7 @@ public class LogRepository {
     jdbcTemplate.update(connection -> {
       PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
       ps.setBytes(1, UUIDUtil.uuidStringToBytes(log.getAppKey()));
-      ps.setString(2, log.getLevel().name());
+      ps.setInt(2, log.getLevel().ordinal());
       ps.setString(3, log.getData().getValue());
       ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
       return ps;
@@ -57,7 +57,7 @@ public class LogRepository {
   private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
       rs.getLong("log_id"),
       UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
-      rs.getString("level"),
+      rs.getInt("level"),
       rs.getString("data"),
       rs.getTimestamp("timestamp").toLocalDateTime()
   );


### PR DESCRIPTION
## 🚀 작업 내용
- 로그 레벨 세분화 
```java
public enum Level {
  TRACE, // 0
  DEBUG, // 1
  INFO, // 2
  WARN, // 3
  ERROR; // 4
}
```
- enum 값 추가
- 로그 저장방식 변경 

- enum의 ordinal 값을 사용해서 저장하도록 변경
- feature: log 생성자 추가 

- 정수형 level을 통해서 생성할 수 있도록 추가

## 📸 이슈 번호

- close #81

## ✍ 궁금한 점