### PR TITLE
Feat/#89 Log Insert 시 비동기 Bulk Insert 하도록 구현

### DIFF
--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -18,7 +18,7 @@ public class AsyncLogProcessor {
     private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
     private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
 
-    private final ExecutorService followerExecutor = Executors.newFixedThreadPool(8);
+    private final ExecutorService followerExecutor = Executors.newFixedThreadPool(10);
 
     private static final long DEFAULT_TIMEOUT = 2000L;
     private static final int DEFAULT_BULK_SIZE = 100;

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -85,7 +85,6 @@ public class AsyncLogProcessor {
     private void leaderTask(Consumer<List<Log>> saveFunction) {
         while (!Thread.currentThread().isInterrupted()) {
             try {
-                List<Log> logs = new ArrayList<>();
                 final Log log = logQueue.poll(defaultTimeout, TimeUnit.MILLISECONDS);
                 /*
                  * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
@@ -97,6 +96,7 @@ public class AsyncLogProcessor {
                 if (log == null) {
                     continue;
                 }
+                List<Log> logs = new ArrayList<>();
                 logs.add(log);
                 //drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
                 logQueue.drainTo(logs, defaultBulkSize - 1);

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -35,7 +35,7 @@ public class AsyncLogProcessor {
     private void leaderTask(Consumer<List<Log>> saveFunction) {
         while (!Thread.currentThread().isInterrupted()) {
             try {
-                final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+                final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
                 /**
                  * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
                  *

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -18,7 +18,7 @@ public class AsyncLogProcessor {
     private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
     private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
 
-    private final ExecutorService followerExecutor = Executors.newFixedThreadPool(20);
+    private final ExecutorService followerExecutor = Executors.newFixedThreadPool(8);
 
     private static final long DEFAULT_TIMEOUT = 2000L;
     private static final int DEFAULT_BULK_SIZE = 100;

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -4,54 +4,90 @@ import com.zaxxer.hikari.HikariDataSource;
 import info.logbat.domain.log.domain.Log;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
-import javax.sql.DataSource;
 
+/**
+ * 비동기식 로그 처리를 담당하는 것은 AsyncLogProcessor입니다. 리더-팔로워 패턴을 사용하여 로그 항목을 처리하고 대량으로 저장합니다. 리더는 로그 큐에서 로그
+ * 항목을 가져와 팔로워 스레드 풀에 전달합니다. 팔로워는 로그 항목을 대량으로 저장합니다.
+ */
 @Slf4j
 @Component
 public class AsyncLogProcessor {
 
     private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
-    private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
-
     private final ExecutorService followerExecutor;
+    private final long defaultTimeout;
+    private final int defaultBulkSize;
 
-    private static final long DEFAULT_TIMEOUT = 2000L;
-    private static final int DEFAULT_BULK_SIZE = 100;
 
-    public AsyncLogProcessor(JdbcTemplate jdbcTemplate) {
+    /**
+     * 지정된 시간 제한, 일괄 크기 및 JdbcTemplate을 사용하여 AsyncLogProcessor를 구축합니다.
+     *
+     * @param timeout      팔로워 스레드가 대기하는 시간 제한
+     * @param bulkSize     팔로워 스레드가 한 번에 처리하는 로그 항목 수
+     * @param jdbcTemplate JdbcTemplate
+     */
+    public AsyncLogProcessor(@Value("${jdbc.async.timeout}") Long timeout,
+        @Value("${jdbc.async.bulk-size}") Integer bulkSize, JdbcTemplate jdbcTemplate) {
         DataSource dataSource = jdbcTemplate.getDataSource();
-        if (dataSource == null || !(dataSource instanceof HikariDataSource)) {
+        if (!(dataSource instanceof HikariDataSource)) {
             throw new IllegalArgumentException("DataSource is null");
         }
         int poolSize = ((HikariDataSource) dataSource).getMaximumPoolSize();
 
         // use 50% of the pool size for the follower thread pool
         followerExecutor = Executors.newFixedThreadPool(poolSize * 5 / 10);
+        this.defaultTimeout = Objects.requireNonNullElse(timeout, 2000L);
+        this.defaultBulkSize = Objects.requireNonNullElse(bulkSize, 100);
     }
 
+    /**
+     * 비동기식 로그 처리를 시작합니다. 리더 스레드를 시작하고 로그 저장 함수를 전달합니다.
+     *
+     * @param saveFunction 로그 저장 함수
+     */
     public void init(Consumer<List<Log>> saveFunction) {
-        leaderExecutor.execute(() -> leaderTask(saveFunction));
+        CompletableFuture.runAsync(() -> leaderTask(saveFunction));
     }
 
+    /**
+     * 로그를 제출합니다.
+     * <p>
+     * 로그 큐에 로그를 추가합니다.
+     *
+     * @param log 로그
+     */
     public void submitLog(Log log) {
         // Queue 크기를 제한할 거면 offer 사용하도록 변경
         logQueue.add(log);
     }
 
+    /**
+     * 리더 스레드를 시작합니다. 로그를 저장하는 함수를 전달합니다.
+     * <p>
+     * 리더 스레드는 로그 큐에서 로그 항목을 가져와 팔로워 스레드 풀에 전달합니다. 팔로워는 로그 항목을 대량으로 저장합니다. 리더 스레드는 종료되지 않는 한 계속해서
+     * 로그를 처리합니다. 리더 스레드가 종료되면 팔로워 스레드 풀도 종료됩니다.
+     *
+     * @param saveFunction 로그 저장 함수
+     */
     private void leaderTask(Consumer<List<Log>> saveFunction) {
         while (!Thread.currentThread().isInterrupted()) {
             try {
-                final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-                /**
+                List<Log> logs = new ArrayList<>();
+                final Log log = logQueue.poll(defaultTimeout, TimeUnit.MILLISECONDS);
+                /*
                  * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
                  *
                  * Log가 높은 부하로 들어오는 경우 Bulk Size만큼 한 번에 저장
@@ -61,19 +97,12 @@ public class AsyncLogProcessor {
                 if (log == null) {
                     continue;
                 }
-
-                List<Log> logs = new ArrayList<>();
                 logs.add(log);
-                /**
-                 * drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
-                 */
-                logQueue.drainTo(logs, DEFAULT_BULK_SIZE - 1);
-
-                /**
-                 * Follower Thread Pool에 저장 요청
-                 */
-                // TODO 저장에 실패했을 때의 추가 로직이 필요합니다.
+                //drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
+                logQueue.drainTo(logs, defaultBulkSize - 1);
+                // Follower Thread Pool에 저장 요청
                 followerExecutor.execute(() -> saveFunction.accept(logs));
+
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.error("Leader thread was interrupted. Exiting.", e);

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogProcessor.java
@@ -1,0 +1,71 @@
+package info.logbat.domain.log.repository;
+
+import info.logbat.domain.log.domain.Log;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AsyncLogProcessor {
+
+    private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
+    private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
+
+    private final ExecutorService followerExecutor = Executors.newFixedThreadPool(20);
+
+    private static final long DEFAULT_TIMEOUT = 2000L;
+    private static final int DEFAULT_BULK_SIZE = 100;
+
+    public void init(Consumer<List<Log>> saveFunction) {
+        leaderExecutor.execute(() -> leaderTask(saveFunction));
+    }
+
+    public void submitLog(Log log) {
+        // Queue 크기를 제한할 거면 offer 사용하도록 변경
+        logQueue.add(log);
+    }
+
+    private void leaderTask(Consumer<List<Log>> saveFunction) {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+                /**
+                 * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
+                 *
+                 * Log가 높은 부하로 들어오는 경우 Bulk Size만큼 한 번에 저장
+                 *
+                 * Timeout동안 들어온 Log가 없는 경우 다음 반복문 cycle 수행
+                 */
+                if (log == null) {
+                    continue;
+                }
+
+                List<Log> logs = new ArrayList<>();
+                logs.add(log);
+                /**
+                 * drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
+                 */
+                logQueue.drainTo(logs, DEFAULT_BULK_SIZE - 1);
+
+                /**
+                 * Follower Thread Pool에 저장 요청
+                 */
+                // TODO 저장에 실패했을 때의 추가 로직이 필요합니다.
+                followerExecutor.execute(() -> saveFunction.accept(logs));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Leader thread was interrupted. Exiting.", e);
+                break;
+            } catch (Exception e) {
+                log.error("Unexpected error in leader thread", e);
+            }
+        }
+    }
+}

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
@@ -1,6 +1,5 @@
 package info.logbat.domain.log.repository;
 
-import info.logbat.common.util.UUIDUtil;
 import info.logbat.domain.log.domain.Log;
 import jakarta.annotation.PostConstruct;
 import java.sql.Timestamp;
@@ -39,7 +38,7 @@ public class AsyncLogRepository implements LogRepository {
 
     @Override
     public Optional<Log> findById(Long logId) {
-        String sql = "SELECT * FROM logs WHERE log_id = ?";
+        String sql = "SELECT * FROM logs WHERE id = ?";
 
         try {
             return Optional.ofNullable(
@@ -59,7 +58,7 @@ public class AsyncLogRepository implements LogRepository {
         }
 
         StringBuilder sql = new StringBuilder(
-            "INSERT INTO logs (app_key, level, data, timestamp) VALUES ");
+            "INSERT INTO logs (app_id, level, data, timestamp) VALUES ");
 
         for (int i = 0; i < logs.size(); i++) {
             sql.append("(?, ?, ?, ?)");
@@ -71,7 +70,7 @@ public class AsyncLogRepository implements LogRepository {
         jdbcTemplate.update(sql.toString(), ps -> {
             int paramIndex = 1;
             for (Log log : logs) {
-                ps.setBytes(paramIndex++, UUIDUtil.uuidStringToBytes(log.getAppKey()));
+                ps.setLong(paramIndex++, log.getAppId());
                 ps.setInt(paramIndex++, log.getLevel().ordinal());
                 ps.setString(paramIndex++, log.getData().getValue());
                 ps.setTimestamp(paramIndex++, Timestamp.valueOf(log.getTimestamp()));
@@ -81,7 +80,7 @@ public class AsyncLogRepository implements LogRepository {
 
     private final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
         rs.getLong("log_id"),
-        UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
+        rs.getLong("app_id"),
         rs.getInt("level"),
         rs.getString("data"),
         rs.getTimestamp("timestamp").toLocalDateTime()

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
@@ -1,17 +1,137 @@
 package info.logbat.domain.log.repository;
 
+import info.logbat.common.util.UUIDUtil;
 import info.logbat.domain.log.domain.Log;
+import jakarta.annotation.PostConstruct;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
+@Slf4j
+@Primary
+@Repository
+@RequiredArgsConstructor
 public class AsyncLogRepository implements LogRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
+
+  private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
+  private final ExecutorService followerExecutor = Executors.newFixedThreadPool(20);
+
+  private static final Long DEFAULT_RETURNS = 0L;
+  private static final Long DEFAULT_TIMEOUT = 2000L;
+  private static final Integer DEFAULT_BULK_SIZE = 100;
+
+  @PostConstruct
+  public void init() {
+    log.info("AsyncLogRepository is initialized.");
+    leaderExecutor.execute(this::leaderTask);
+  }
 
   @Override
   public long save(Log log) {
-    return 0;
+    logQueue.add(log);
+    return DEFAULT_RETURNS;
   }
 
   @Override
   public Optional<Log> findById(Long logId) {
-    return Optional.empty();
+    String sql = "SELECT * FROM logs WHERE log_id = ?";
+
+    try {
+      return Optional.ofNullable(
+          jdbcTemplate.queryForObject(
+              sql,
+              LOG_ROW_MAPPER,
+              logId
+          ));
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
   }
+
+  private void leaderTask() {
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+
+        /**
+         * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
+         *
+         * Log가 높은 부하로 들어오는 경우 Bulk Size만큼 한 번에 저장
+         *
+         * Timeout동안 들어온 Log가 없는 경우 다음 반복문 cycle 수행
+         */
+        if (log == null) {
+          continue;
+        }
+        List<Log> logs = new ArrayList<>();
+        logs.add(log);
+
+        /**
+         * drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
+         */
+        logQueue.drainTo(logs, DEFAULT_BULK_SIZE - 1);
+
+        /**
+         * Follower Thread Pool에 저장 요청
+         */
+        followerExecutor.execute(() -> saveLogsToDatabase(logs));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        log.error("Leader thread was interrupted. Exiting.", e);
+        break;
+      } catch (Exception e) {
+        log.error("Unexpected error in leader thread", e);
+      }
+    }
+  }
+
+  private void saveLogsToDatabase(List<Log> logs) {
+    if (logs.isEmpty()) {
+      return;
+    }
+
+    StringBuilder sql = new StringBuilder(
+        "INSERT INTO logs (app_key, level, data, timestamp) VALUES ");
+
+    for (int i = 0; i < logs.size(); i++) {
+      sql.append("(?, ?, ?, ?)");
+      if (i < logs.size() - 1) { // 마지막 요소가 아닌 경우
+        sql.append(", ");
+      }
+    }
+
+    jdbcTemplate.update(sql.toString(), ps -> {
+      int paramIndex = 1;
+      for (Log log : logs) {
+        ps.setBytes(paramIndex++, UUIDUtil.uuidStringToBytes(log.getAppKey()));
+        ps.setInt(paramIndex++, log.getLevel().ordinal());
+        ps.setString(paramIndex++, log.getData().getValue());
+        ps.setTimestamp(paramIndex++, Timestamp.valueOf(log.getTimestamp()));
+      }
+    });
+  }
+
+  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
+      rs.getLong("log_id"),
+      UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
+      rs.getInt("level"),
+      rs.getString("data"),
+      rs.getTimestamp("timestamp").toLocalDateTime()
+  );
+
 }

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
@@ -4,13 +4,8 @@ import info.logbat.common.util.UUIDUtil;
 import info.logbat.domain.log.domain.Log;
 import jakarta.annotation.PostConstruct;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
@@ -25,113 +20,70 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class AsyncLogRepository implements LogRepository {
 
-  private final JdbcTemplate jdbcTemplate;
-  private final LinkedBlockingQueue<Log> logQueue = new LinkedBlockingQueue<>();
+    private final JdbcTemplate jdbcTemplate;
+    private final AsyncLogProcessor asyncLogProcessor;
 
-  private final ExecutorService leaderExecutor = Executors.newSingleThreadExecutor();
-  private final ExecutorService followerExecutor = Executors.newFixedThreadPool(20);
+    private static final Long DEFAULT_RETURNS = 0L;
 
-  private static final Long DEFAULT_RETURNS = 0L;
-  private static final Long DEFAULT_TIMEOUT = 2000L;
-  private static final Integer DEFAULT_BULK_SIZE = 100;
-
-  @PostConstruct
-  public void init() {
-    log.info("AsyncLogRepository is initialized.");
-    leaderExecutor.execute(this::leaderTask);
-  }
-
-  @Override
-  public long save(Log log) {
-    logQueue.add(log);
-    return DEFAULT_RETURNS;
-  }
-
-  @Override
-  public Optional<Log> findById(Long logId) {
-    String sql = "SELECT * FROM logs WHERE log_id = ?";
-
-    try {
-      return Optional.ofNullable(
-          jdbcTemplate.queryForObject(
-              sql,
-              LOG_ROW_MAPPER,
-              logId
-          ));
-    } catch (EmptyResultDataAccessException e) {
-      return Optional.empty();
+    @PostConstruct
+    public void init() {
+        log.info("AsyncLogRepository is initialized.");
+        asyncLogProcessor.init(this::saveLogsToDatabase);
     }
-  }
 
-  private void leaderTask() {
-    while (!Thread.currentThread().isInterrupted()) {
-      try {
-        final Log log = logQueue.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+    @Override
+    public long save(Log log) {
+        asyncLogProcessor.submitLog(log);
+        return DEFAULT_RETURNS;
+    }
 
-        /**
-         * Log가 천천히 들어오는 경우 Timeout에 한 번씩 저장
-         *
-         * Log가 높은 부하로 들어오는 경우 Bulk Size만큼 한 번에 저장
-         *
-         * Timeout동안 들어온 Log가 없는 경우 다음 반복문 cycle 수행
-         */
-        if (log == null) {
-          continue;
+    @Override
+    public Optional<Log> findById(Long logId) {
+        String sql = "SELECT * FROM logs WHERE log_id = ?";
+
+        try {
+            return Optional.ofNullable(
+                jdbcTemplate.queryForObject(
+                    sql,
+                    LOG_ROW_MAPPER,
+                    logId
+                ));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
         }
-        List<Log> logs = new ArrayList<>();
-        logs.add(log);
-
-        /**
-         * drainTo는 Queue에 있는 요소를 maxElements만큼 꺼내서 Collection에 담아준다.
-         */
-        logQueue.drainTo(logs, DEFAULT_BULK_SIZE - 1);
-
-        /**
-         * Follower Thread Pool에 저장 요청
-         */
-        followerExecutor.execute(() -> saveLogsToDatabase(logs));
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        log.error("Leader thread was interrupted. Exiting.", e);
-        break;
-      } catch (Exception e) {
-        log.error("Unexpected error in leader thread", e);
-      }
-    }
-  }
-
-  private void saveLogsToDatabase(List<Log> logs) {
-    if (logs.isEmpty()) {
-      return;
     }
 
-    StringBuilder sql = new StringBuilder(
-        "INSERT INTO logs (app_key, level, data, timestamp) VALUES ");
+    private void saveLogsToDatabase(List<Log> logs) {
+        if (logs.isEmpty()) {
+            return;
+        }
 
-    for (int i = 0; i < logs.size(); i++) {
-      sql.append("(?, ?, ?, ?)");
-      if (i < logs.size() - 1) { // 마지막 요소가 아닌 경우
-        sql.append(", ");
-      }
+        StringBuilder sql = new StringBuilder(
+            "INSERT INTO logs (app_key, level, data, timestamp) VALUES ");
+
+        for (int i = 0; i < logs.size(); i++) {
+            sql.append("(?, ?, ?, ?)");
+            if (i < logs.size() - 1) { // 마지막 요소가 아닌 경우에만 콤마 추가
+                sql.append(", ");
+            }
+        }
+
+        jdbcTemplate.update(sql.toString(), ps -> {
+            int paramIndex = 1;
+            for (Log log : logs) {
+                ps.setBytes(paramIndex++, UUIDUtil.uuidStringToBytes(log.getAppKey()));
+                ps.setInt(paramIndex++, log.getLevel().ordinal());
+                ps.setString(paramIndex++, log.getData().getValue());
+                ps.setTimestamp(paramIndex++, Timestamp.valueOf(log.getTimestamp()));
+            }
+        });
     }
 
-    jdbcTemplate.update(sql.toString(), ps -> {
-      int paramIndex = 1;
-      for (Log log : logs) {
-        ps.setBytes(paramIndex++, UUIDUtil.uuidStringToBytes(log.getAppKey()));
-        ps.setInt(paramIndex++, log.getLevel().ordinal());
-        ps.setString(paramIndex++, log.getData().getValue());
-        ps.setTimestamp(paramIndex++, Timestamp.valueOf(log.getTimestamp()));
-      }
-    });
-  }
-
-  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
-      rs.getLong("log_id"),
-      UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
-      rs.getInt("level"),
-      rs.getString("data"),
-      rs.getTimestamp("timestamp").toLocalDateTime()
-  );
-
+    private final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
+        rs.getLong("log_id"),
+        UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
+        rs.getInt("level"),
+        rs.getString("data"),
+        rs.getTimestamp("timestamp").toLocalDateTime()
+    );
 }

--- a/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/AsyncLogRepository.java
@@ -1,0 +1,17 @@
+package info.logbat.domain.log.repository;
+
+import info.logbat.domain.log.domain.Log;
+import java.util.Optional;
+
+public class AsyncLogRepository implements LogRepository {
+
+  @Override
+  public long save(Log log) {
+    return 0;
+  }
+
+  @Override
+  public Optional<Log> findById(Long logId) {
+    return Optional.empty();
+  }
+}

--- a/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/LogRepository.java
@@ -1,64 +1,11 @@
 package info.logbat.domain.log.repository;
 
-import info.logbat.common.util.UUIDUtil;
 import info.logbat.domain.log.domain.Log;
-import java.sql.PreparedStatement;
-import java.sql.Statement;
-import java.sql.Timestamp;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
-import org.springframework.stereotype.Repository;
 
-@Repository
-@RequiredArgsConstructor
-public class LogRepository {
+public interface LogRepository {
 
-  private final JdbcTemplate jdbcTemplate;
+  long save(Log log);
 
-  public long save(Log log) {
-    String sql = "INSERT INTO logs (app_key, level, data, timestamp) VALUES (?, ?, ?, ?)";
-
-    KeyHolder keyHolder = new GeneratedKeyHolder();
-
-    jdbcTemplate.update(connection -> {
-      PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
-      ps.setBytes(1, UUIDUtil.uuidStringToBytes(log.getAppKey()));
-      ps.setInt(2, log.getLevel().ordinal());
-      ps.setString(3, log.getData().getValue());
-      ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
-      return ps;
-    }, keyHolder);
-
-    return Optional.ofNullable(keyHolder.getKey())
-        .map(Number::longValue)
-        .orElseThrow(() -> new IllegalStateException("로그 저장에 실패했습니다."));
-  }
-
-  public Optional<Log> findById(Long logId) {
-    String sql = "SELECT * FROM logs WHERE log_id = ?";
-
-    try {
-      return Optional.ofNullable(
-          jdbcTemplate.queryForObject(
-              sql,
-              LOG_ROW_MAPPER,
-              logId
-          ));
-    } catch (EmptyResultDataAccessException e) {
-      return Optional.empty();
-    }
-  }
-
-  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
-      rs.getLong("log_id"),
-      UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
-      rs.getInt("level"),
-      rs.getString("data"),
-      rs.getTimestamp("timestamp").toLocalDateTime()
-  );
+  Optional<Log> findById(Long logId);
 }

--- a/logbat/src/main/java/info/logbat/domain/log/repository/SynchronousLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/SynchronousLogRepository.java
@@ -1,0 +1,66 @@
+package info.logbat.domain.log.repository;
+
+import info.logbat.common.util.UUIDUtil;
+import info.logbat.domain.log.domain.Log;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SynchronousLogRepository implements LogRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public long save(Log log) {
+    String sql = "INSERT INTO logs (app_key, level, data, timestamp) VALUES (?, ?, ?, ?)";
+
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+
+    jdbcTemplate.update(connection -> {
+      PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+      ps.setBytes(1, UUIDUtil.uuidStringToBytes(log.getAppKey()));
+      ps.setInt(2, log.getLevel().ordinal());
+      ps.setString(3, log.getData().getValue());
+      ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
+      return ps;
+    }, keyHolder);
+
+    return Optional.ofNullable(keyHolder.getKey())
+        .map(Number::longValue)
+        .orElseThrow(() -> new IllegalStateException("로그 저장에 실패했습니다."));
+  }
+
+  @Override
+  public Optional<Log> findById(Long logId) {
+    String sql = "SELECT * FROM logs WHERE log_id = ?";
+
+    try {
+      return Optional.ofNullable(
+          jdbcTemplate.queryForObject(
+              sql,
+              LOG_ROW_MAPPER,
+              logId
+          ));
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
+      rs.getLong("log_id"),
+      UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
+      rs.getInt("level"),
+      rs.getString("data"),
+      rs.getTimestamp("timestamp").toLocalDateTime()
+  );
+}

--- a/logbat/src/main/java/info/logbat/domain/log/repository/SynchronousLogRepository.java
+++ b/logbat/src/main/java/info/logbat/domain/log/repository/SynchronousLogRepository.java
@@ -1,6 +1,5 @@
 package info.logbat.domain.log.repository;
 
-import info.logbat.common.util.UUIDUtil;
 import info.logbat.domain.log.domain.Log;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
@@ -18,49 +17,50 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class SynchronousLogRepository implements LogRepository {
 
-  private final JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
 
-  @Override
-  public long save(Log log) {
-    String sql = "INSERT INTO logs (app_key, level, data, timestamp) VALUES (?, ?, ?, ?)";
+    @Override
+    public long save(Log log) {
+        String sql = "INSERT INTO logs (app_id, level, data, timestamp) VALUES (?, ?, ?, ?)";
 
-    KeyHolder keyHolder = new GeneratedKeyHolder();
+        KeyHolder keyHolder = new GeneratedKeyHolder();
 
-    jdbcTemplate.update(connection -> {
-      PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
-      ps.setBytes(1, UUIDUtil.uuidStringToBytes(log.getAppKey()));
-      ps.setInt(2, log.getLevel().ordinal());
-      ps.setString(3, log.getData().getValue());
-      ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
-      return ps;
-    }, keyHolder);
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql,
+                Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, log.getAppId());
+            ps.setInt(2, log.getLevel().ordinal());
+            ps.setString(3, log.getData().getValue());
+            ps.setTimestamp(4, Timestamp.valueOf(log.getTimestamp()));
+            return ps;
+        }, keyHolder);
 
-    return Optional.ofNullable(keyHolder.getKey())
-        .map(Number::longValue)
-        .orElseThrow(() -> new IllegalStateException("로그 저장에 실패했습니다."));
-  }
-
-  @Override
-  public Optional<Log> findById(Long logId) {
-    String sql = "SELECT * FROM logs WHERE log_id = ?";
-
-    try {
-      return Optional.ofNullable(
-          jdbcTemplate.queryForObject(
-              sql,
-              LOG_ROW_MAPPER,
-              logId
-          ));
-    } catch (EmptyResultDataAccessException e) {
-      return Optional.empty();
+        return Optional.ofNullable(keyHolder.getKey())
+            .map(Number::longValue)
+            .orElseThrow(() -> new IllegalStateException("로그 저장에 실패했습니다."));
     }
-  }
 
-  private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
-      rs.getLong("log_id"),
-      UUIDUtil.bytesToUuidString(rs.getBytes("app_key")),
-      rs.getInt("level"),
-      rs.getString("data"),
-      rs.getTimestamp("timestamp").toLocalDateTime()
-  );
+    @Override
+    public Optional<Log> findById(Long id) {
+        String sql = "SELECT * FROM logs WHERE id = ?";
+
+        try {
+            return Optional.ofNullable(
+                jdbcTemplate.queryForObject(
+                    sql,
+                    LOG_ROW_MAPPER,
+                    id
+                ));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static final RowMapper<Log> LOG_ROW_MAPPER = (rs, rowNum) -> new Log(
+        rs.getLong("id"),
+        rs.getLong("app_id"),
+        rs.getInt("level"),
+        rs.getString("data"),
+        rs.getTimestamp("timestamp").toLocalDateTime()
+    );
 }

--- a/logbat/src/main/resources/application.properties
+++ b/logbat/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=logbat

--- a/logbat/src/main/resources/application.yml
+++ b/logbat/src/main/resources/application.yml
@@ -1,0 +1,41 @@
+spring:
+  application:
+    name: logbat
+
+  profiles:
+    active: local
+jdbc:
+  async:
+    timeout: 2000
+    bulk-size: 100
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/logbat
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/logbat
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none

--- a/logbat/src/test/java/info/logbat/domain/log/application/LogServiceTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/application/LogServiceTest.java
@@ -1,11 +1,9 @@
 package info.logbat.domain.log.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import info.logbat.domain.log.application.payload.request.CreateLogServiceRequest;
-import info.logbat.domain.log.domain.Log;
-import info.logbat.domain.log.domain.enums.Level;
 import info.logbat.domain.log.repository.LogRepository;
 import info.logbat.domain.project.domain.App;
 import info.logbat.domain.project.domain.Project;
@@ -13,7 +11,6 @@ import info.logbat.domain.project.domain.enums.AppType;
 import info.logbat.domain.project.repository.AppJpaRepository;
 import info.logbat.domain.project.repository.ProjectJpaRepository;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,16 +60,9 @@ class LogServiceTest {
         CreateLogServiceRequest 요청_DTO = new CreateLogServiceRequest(앱_키.toString(), 로그_레벨, 로그_데이터,
             타임스탬프);
 
-        // when
-        long 저장된_ID = logService.saveLog(요청_DTO);
-
-        // then
-        Optional<Log> 찾은_로그 = logRepository.findById(저장된_ID);
-
-        assertThat(찾은_로그).isPresent()
-            .get()
-            .extracting("logId", "appKey", "level", "data.value", "timestamp")
-            .contains(저장된_ID, 앱_키.toString(), Level.INFO, "테스트_로그_데이터", 타임스탬프);
+        // when & then
+        assertThatCode(() -> logService.saveLog(요청_DTO))
+            .doesNotThrowAnyException();
     }
 
     @DisplayName("존재하지 않는 Application Key로 Log를 저장할 수 없다.")

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
@@ -13,16 +13,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @DisplayName("AsyncLogProcessor 기능 테스트")
 class AsyncLogProcessorTest {
 
-    @Mock
-    private JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
-    @Mock
-    private HikariDataSource hikariDataSource;
+    private final HikariDataSource hikariDataSource = Mockito.mock(HikariDataSource.class);
 
     private AsyncLogProcessor asyncLogProcessor;
     private AtomicInteger processedLogCount;

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -33,7 +32,7 @@ class AsyncLogProcessorTest {
         when(jdbcTemplate.getDataSource()).thenReturn(hikariDataSource);
         when(hikariDataSource.getMaximumPoolSize()).thenReturn(10); // 원하는 풀 사이즈 설정
 
-        asyncLogProcessor = new AsyncLogProcessor(jdbcTemplate);
+        asyncLogProcessor = new AsyncLogProcessor(2000L, 100, jdbcTemplate);
         processedLogCount = new AtomicInteger(0);
     }
 

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
@@ -1,7 +1,9 @@
 package info.logbat.domain.log.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import com.zaxxer.hikari.HikariDataSource;
 import info.logbat.domain.log.domain.Log;
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
@@ -10,9 +12,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @DisplayName("AsyncLogProcessor 기능 테스트")
 class AsyncLogProcessorTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private HikariDataSource hikariDataSource;
 
     private AsyncLogProcessor asyncLogProcessor;
     private AtomicInteger processedLogCount;
@@ -20,7 +30,11 @@ class AsyncLogProcessorTest {
 
     @BeforeEach
     void setUp() {
-        asyncLogProcessor = new AsyncLogProcessor();
+        // HikariDataSource 모킹
+        when(jdbcTemplate.getDataSource()).thenReturn(hikariDataSource);
+        when(hikariDataSource.getMaximumPoolSize()).thenReturn(10); // 원하는 풀 사이즈 설정
+
+        asyncLogProcessor = new AsyncLogProcessor(jdbcTemplate);
         processedLogCount = new AtomicInteger(0);
     }
 

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
@@ -1,0 +1,73 @@
+package info.logbat.domain.log.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import info.logbat.domain.log.domain.Log;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AsyncLogProcessor 기능 테스트")
+class AsyncLogProcessorTest {
+
+    private AsyncLogProcessor asyncLogProcessor;
+    private AtomicInteger processedLogCount;
+    private CountDownLatch latch;
+
+    @BeforeEach
+    void setUp() {
+        asyncLogProcessor = new AsyncLogProcessor();
+        processedLogCount = new AtomicInteger(0);
+    }
+
+    @DisplayName("단일 로그 제출 및 처리 확인")
+    @Test
+    void testSubmitSingleLog() throws InterruptedException {
+        // given
+        latch = new CountDownLatch(1);
+        asyncLogProcessor.init(logs -> {
+            processedLogCount.addAndGet(logs.size());
+            latch.countDown();
+        });
+
+        Log log = new Log(1L, UUID.randomUUID().toString(), 0, "Test log",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+
+        // when
+        asyncLogProcessor.submitLog(log);
+
+        // then
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(processedLogCount.get())
+            .isEqualTo(1);
+    }
+
+    @DisplayName("벌크 로그 제출 및 처리 확인")
+    @Test
+    void testSubmitBulkLogs() throws InterruptedException {
+        // given
+        int logCount = 150; // DEFAULT_BULK_SIZE(100)보다 큰 값
+        latch = new CountDownLatch(2); // 최소 2번의 처리를 기대
+        asyncLogProcessor.init(logs -> {
+            processedLogCount.addAndGet(logs.size());
+            latch.countDown();
+        });
+
+        // when
+        for (int i = 0; i < logCount; i++) {
+            asyncLogProcessor.submitLog(
+                new Log((long) i, UUID.randomUUID().toString(), 0, "Test log " + i,
+                    LocalDateTime.of(2021, 1, 1, 0, 0, 0)));
+        }
+
+        // then
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(processedLogCount.get()).isEqualTo(logCount);
+    }
+
+}

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogProcessorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import info.logbat.domain.log.domain.Log;
 import java.time.LocalDateTime;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,8 +33,9 @@ class AsyncLogProcessorTest {
             processedLogCount.addAndGet(logs.size());
             latch.countDown();
         });
+        Long 앱_ID = 1L;
 
-        Log log = new Log(1L, UUID.randomUUID().toString(), 0, "Test log",
+        Log log = new Log(1L, 앱_ID, 0, "Test log",
             LocalDateTime.of(2021, 1, 1, 0, 0, 0));
 
         // when
@@ -58,10 +58,12 @@ class AsyncLogProcessorTest {
             latch.countDown();
         });
 
+        Long 앱_ID = 1L;
+
         // when
         for (int i = 0; i < logCount; i++) {
             asyncLogProcessor.submitLog(
-                new Log((long) i, UUID.randomUUID().toString(), 0, "Test log " + i,
+                new Log((long) i, 앱_ID, 0, "Test log " + i,
                     LocalDateTime.of(2021, 1, 1, 0, 0, 0)));
         }
 

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogRepositoryTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import info.logbat.domain.log.domain.Log;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +36,7 @@ class AsyncLogRepositoryTest {
     @Test
     void testSave() {
         // given
-        Log log = new Log(1L, UUID.randomUUID().toString(), 0, "Test log data",
+        Log log = new Log(1L, 1L, 0, "Test log data",
             LocalDateTime.of(2021, 1, 1, 0, 0, 0));
 
         // When
@@ -53,7 +52,7 @@ class AsyncLogRepositoryTest {
     void testFindById_WhenLogExists() {
         // given
         Long logId = 1L;
-        Log expectedLog = new Log(logId, UUID.randomUUID().toString(), 0, "Test log data",
+        Log expectedLog = new Log(logId, 1L, 0, "Test log data",
             LocalDateTime.of(2021, 1, 1, 0, 0, 0));
         when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), eq(logId)))
             .thenReturn(expectedLog);

--- a/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/AsyncLogRepositoryTest.java
@@ -1,0 +1,83 @@
+package info.logbat.domain.log.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import info.logbat.domain.log.domain.Log;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+@DisplayName("AsyncLogRepository 테스트")
+@SpringBootTest
+class AsyncLogRepositoryTest {
+
+    @MockBean
+    private JdbcTemplate jdbcTemplate;
+
+    @MockBean
+    private AsyncLogProcessor asyncLogProcessor;
+
+    @Autowired
+    private AsyncLogRepository asyncLogRepository;
+
+    @DisplayName("AsyncLogProcessor에 로그가 전달되는지 확인")
+    @Test
+    void testSave() {
+        // given
+        Log log = new Log(1L, UUID.randomUUID().toString(), 0, "Test log data",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+
+        // When
+        long result = asyncLogRepository.save(log);
+
+        // Then
+        assertThat(0L).isEqualTo(result);
+        verify(asyncLogProcessor).submitLog(log);
+    }
+
+    @DisplayName("존재하는 로그 ID인 경우 Optional에 로그 반환")
+    @Test
+    void testFindById_WhenLogExists() {
+        // given
+        Long logId = 1L;
+        Log expectedLog = new Log(logId, UUID.randomUUID().toString(), 0, "Test log data",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), eq(logId)))
+            .thenReturn(expectedLog);
+
+        // When
+        Optional<Log> result = asyncLogRepository.findById(logId);
+
+        // Then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(expectedLog);
+    }
+
+    @DisplayName("존재하지 않는 로그 ID인 경우 빈 Optional 반환")
+    @Test
+    void testFindById_WhenLogDoesNotExist() {
+        // given
+        Long logId = 1L;
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), eq(logId)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+
+        // When
+        Optional<Log> result = asyncLogRepository.findById(logId);
+
+        // Then
+        assertThat(result.isPresent()).isFalse();
+    }
+}

--- a/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
@@ -17,8 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-@DisplayName("LogRepository 테스트")
-class LogRepositoryTest {
+@DisplayName("SynchoronousLogRepository 테스트")
+class SynchronousLogRepositoryTest {
 
   @Autowired
   private LogRepository logRepository;

--- a/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
@@ -31,9 +31,10 @@ class SynchronousLogRepositoryTest {
         // given
         String 로그_레벨 = "INFO";
         String 로그_데이터 = "테스트_로그_데이터";
+        Long 앱_ID = 1L;
         LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
 
-        Log 로그 = new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프);
+        Log 로그 = new Log(앱_ID, 로그_레벨, 로그_데이터, 타임스탬프);
 
         // when
         long 저장된_ID = synchronousLogRepository.save(로그);
@@ -49,9 +50,10 @@ class SynchronousLogRepositoryTest {
         // given
         String 로그_레벨 = "INFO";
         String 로그_데이터 = "테스트_로그_데이터";
+        Long 앱_ID = 1L;
         LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
 
-        long 로그_ID = synchronousLogRepository.save(new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프));
+        long 로그_ID = synchronousLogRepository.save(new Log(앱_ID, 로그_레벨, 로그_데이터, 타임스탬프));
 
         // when
         Optional<Log> 저장된_로그 = synchronousLogRepository.findById(로그_ID);
@@ -59,8 +61,8 @@ class SynchronousLogRepositoryTest {
         // then
         assertThat(저장된_로그).isPresent()
             .get()
-            .extracting("logId", "appKey", "level", "data.value", "timestamp")
-            .containsExactly(로그_ID, 앱_키_문자열, Level.INFO, "테스트_로그_데이터",
+            .extracting("id", "appId", "level", "data.value", "timestamp")
+            .containsExactly(로그_ID, 앱_ID, Level.INFO, "테스트_로그_데이터",
                 LocalDateTime.of(2021, 1, 1, 0, 0, 0));
     }
 

--- a/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
+++ b/logbat/src/test/java/info/logbat/domain/log/repository/SynchronousLogRepositoryTest.java
@@ -20,60 +20,60 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayName("SynchoronousLogRepository 테스트")
 class SynchronousLogRepositoryTest {
 
-  @Autowired
-  private LogRepository logRepository;
+    @Autowired
+    private SynchronousLogRepository synchronousLogRepository;
 
-  private static final String 앱_키_문자열 = UUID.randomUUID().toString();
+    private static final String 앱_키_문자열 = UUID.randomUUID().toString();
 
-  @DisplayName("Log를 저장할 수 있다.")
-  @Test
-  void saveLog() {
-    // given
-    String 로그_레벨 = "INFO";
-    String 로그_데이터 = "테스트_로그_데이터";
-    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+    @DisplayName("Log를 저장할 수 있다.")
+    @Test
+    void saveLog() {
+        // given
+        String 로그_레벨 = "INFO";
+        String 로그_데이터 = "테스트_로그_데이터";
+        LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
 
-    Log 로그 = new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프);
+        Log 로그 = new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프);
 
-    // when
-    long 저장된_ID = logRepository.save(로그);
+        // when
+        long 저장된_ID = synchronousLogRepository.save(로그);
 
-    // then
-    assertThat(저장된_ID)
-        .isPositive();
-  }
+        // then
+        assertThat(저장된_ID)
+            .isPositive();
+    }
 
-  @DisplayName("저장한 Log를 조회할 수 있다.")
-  @Test
-  void findLog() {
-    // given
-    String 로그_레벨 = "INFO";
-    String 로그_데이터 = "테스트_로그_데이터";
-    LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
+    @DisplayName("저장한 Log를 조회할 수 있다.")
+    @Test
+    void findLog() {
+        // given
+        String 로그_레벨 = "INFO";
+        String 로그_데이터 = "테스트_로그_데이터";
+        LocalDateTime 타임스탬프 = LocalDateTime.of(2021, 1, 1, 0, 0, 0);
 
-    long 로그_ID = logRepository.save(new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프));
+        long 로그_ID = synchronousLogRepository.save(new Log(앱_키_문자열, 로그_레벨, 로그_데이터, 타임스탬프));
 
-    // when
-    Optional<Log> 저장된_로그 = logRepository.findById(로그_ID);
+        // when
+        Optional<Log> 저장된_로그 = synchronousLogRepository.findById(로그_ID);
 
-    // then
-    assertThat(저장된_로그).isPresent()
-        .get()
-        .extracting("logId", "appKey", "level", "data.value", "timestamp")
-        .containsExactly(로그_ID, 앱_키_문자열, Level.INFO, "테스트_로그_데이터",
-            LocalDateTime.of(2021, 1, 1, 0, 0, 0));
-  }
+        // then
+        assertThat(저장된_로그).isPresent()
+            .get()
+            .extracting("logId", "appKey", "level", "data.value", "timestamp")
+            .containsExactly(로그_ID, 앱_키_문자열, Level.INFO, "테스트_로그_데이터",
+                LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+    }
 
-  @DisplayName("없는 Log를 조회하면 빈 Optional을 반환한다.")
-  @Test
-  void findNonexistentLog() {
-    // given
-    long 없는_로그_ID = 1L;
+    @DisplayName("없는 Log를 조회하면 빈 Optional을 반환한다.")
+    @Test
+    void findNonexistentLog() {
+        // given
+        long 없는_로그_ID = 1L;
 
-    // when
-    Optional<Log> 저장된_로그 = logRepository.findById(없는_로그_ID);
+        // when
+        Optional<Log> 저장된_로그 = synchronousLogRepository.findById(없는_로그_ID);
 
-    // then
-    assertThat(저장된_로그).isEmpty();
-  }
+        // then
+        assertThat(저장된_로그).isEmpty();
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- LogRepository 인터페이스 분리
- AsyncLogRepository 및 AsyncLogProcessor 구현
- SynchronousLogRepository로 기존 구현 이동

- AsyncLogRepository: 비동기 로그 저장을 위한 구현체
    - AsyncLogProcessor의 LinkedBlockingQueue를 사용하여 로그 큐를 관리하도록 구현했습니다.

- 리더 스레드, 팔로워 스레드를 분리하여 비동기 bulk insert를 구현했습니다.

### 동작 방식:
**리더 스레드 (단일 스레드)**
- 리더 스레드에서 LinkedBlockingQueue에서 로그를 폴링 (타임아웃 2초)
    - 로그가 있으면 최대 100개까지 모아서 벌크 처리 준비, 100개 이하라도 저장하도록 구현
    - 준비된 로그를 팔로워 스레드 풀에 전달

**팔로워 스레드 풀 (사이즈는 임시로 HikariCP 사이즈와 1:1로 설정)**
- 리더 스레드로부터 받은 로그를 데이터베이스에 bulk insert 합니다.

위처럼 구현하여 Queue에 로그가 있는지 확인하는 역할은 **리더 단일 스레드에서만** 수행, 큐가 비어있을 경우의 폴링 간격을 2초로 설정하여 폴링하는 CPU 부하를 최소화하도록 설계했습니다.


### 테스트 방법
- AsyncLogRepository는 AsyncLogProcessor를 Moking하여 메서드가 호출되었는지만 verify하는 방식으로 구현했습니다.
- AsyncLogProcessor는 init() 메서드에 전달되는 saveFunction을 CountDownLatch를 이용하는 mock으로 구현하여 로그 처리를 시뮬레이션 했습니다.


## 📸 이슈 번호

- close #89 

## 👀 Focus Commits [Optional]

- 커밋해시: 내용

## ✍ 궁금한 점

- 비동기 코드에 대한 테스트 전략에 고민이 많았습니다,, 어떻게 해야 더 확실하게 검증할 수 있을지 고민됩니다. 
