### PR TITLE
Feat/#107 Maven 배포 구성 및 의존성 추가

### DIFF
--- a/sdk/java/logbat-sdk/build.gradle
+++ b/sdk/java/logbat-sdk/build.gradle
@@ -1,9 +1,10 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 group = 'info.logbat'
-version = '1.0-SNAPSHOT'
+version = '0.1.1'
 
 repositories {
     mavenCentral()
@@ -15,9 +16,26 @@ java {
     }
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            name = "local-repo"
+            url = project.layout.buildDirectory.dir("java").get().asFile.toURI()
+        }
+    }
+}
+
 dependencies {
     // logback
     implementation 'ch.qos.logback:logback-classic:1.4.14'
+
+    // slf4j
+    implementation 'org.slf4j:slf4j-api:1.7.36'
 
     // objectMapper
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
@@ -42,5 +60,10 @@ jar {
                 'Implementation-Title': 'Logbat SDK',
                 'Implementation-Version': version
         )
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE // 중복된 파일 무시
+    
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }


### PR DESCRIPTION
<!-- PR 템플릿 -->
## 🚀 작업 내용
1. **Maven 배포 구성**:
   - `maven-publish` 플러그인을 추가하여 배포 기능을 활성화했습니다.
   - 프로젝트의 Java 컴포넌트를 포함하는 `mavenJava`라는 배포 구성을 추가했습니다.
   - 빌드된 아티팩트를 `build/java` 디렉토리에 저장하는 로컬 Maven 리포지토리(`local-repo`)를 설정했습니다.

2. **Java Toolchain**:
   - 프로젝트의 언어 버전을 Java 17로 설정하여 최신 Java 기능과의 호환성을 보장했습니다.

3. **의존성 추가**:
   - 로깅 기능을 위한 `logback-classic` 의존성을 추가했습니다.
   - SLF4J 로깅 퍼사드를 사용하기 위해 `slf4j-api`를 추가했습니다.
   - JSON 직렬화 및 역직렬화를 위한 `jackson-databind` 의존성을 포함했습니다.

## 📸 이슈 번호

- close #107 

## 👀 Focus Commits [Optional]

- 커밋해시: 내용

## ✍ 궁금한 점
- 중점적으로 봐줄 내용
- 변수명 괜찮나요
- 로직이 좀 더럽나요
- 가독성이 좀 그런가요?
