### PR TITLE
Feat/#118 /favicon.ico에 대한 파일 내려주기 추가

### DIFF
--- a/nginx/sites-available/default
+++ b/nginx/sites-available/default
@@ -3,6 +3,8 @@ server {
     listen [::]:80;
     server_name www.logbat.info logbat.info api.logbat.info sdk.logbat.info view.logbat.info nginx.logbat.info;
 
+    include /etc/nginx/snippets/favicon.conf;
+
     return 301 https://$host$request_uri; # HTTP 요청을 HTTPS로 리디렉션
 }
 
@@ -13,6 +15,8 @@ server {
 
     # managed by Certbot
     include /etc/nginx/snippets/managed-by-Certbot.conf;
+
+    include /etc/nginx/snippets/favicon.conf;
 
     include /etc/nginx/snippets/private-ip.conf;
 
@@ -32,6 +36,8 @@ server {
 
     # managed by Certbot
     include /etc/nginx/snippets/managed-by-Certbot.conf;
+
+    include /etc/nginx/snippets/favicon.conf;
 
     include /etc/nginx/snippets/private-ip.conf;
 
@@ -80,6 +86,8 @@ server {
     # managed by Certbot
     include /etc/nginx/snippets/managed-by-Certbot.conf;
 
+    include /etc/nginx/snippets/favicon.conf;
+
     root /var/www/sdk;  # 정적 파일이 있는 경로로 설정하세요
 
     location / {
@@ -94,6 +102,8 @@ server {
 
     # managed by Certbot
     include /etc/nginx/snippets/managed-by-Certbot.conf;
+
+    include /etc/nginx/snippets/favicon.conf;
 
     include /etc/nginx/snippets/private-ip.conf;
 
@@ -113,6 +123,8 @@ server {
 
     # managed by Certbot
     include /etc/nginx/snippets/managed-by-Certbot.conf;
+
+    include /etc/nginx/snippets/favicon.conf;
 
     include /etc/nginx/snippets/auth-value.conf;
 

--- a/nginx/snippets/favicon.conf
+++ b/nginx/snippets/favicon.conf
@@ -1,0 +1,5 @@
+location /favicon.ico {
+    alias /var/www/favicon.ico;
+    access_log off;  # 로깅 비활성화 (선택 사항)
+    log_not_found off;  # 파일이 없을 때 에러 로그 비활성화 (선택 사항)
+}


### PR DESCRIPTION
## 🚀 작업 내용
- nginx에서 favicon.ico를 내려줄 수 있도록 설정
<img width="223" alt="image" src="https://github.com/user-attachments/assets/991d8f96-209e-4567-9941-ad778a45842d">


## 📸 이슈 번호

- close #118 

## ✍ 궁금한 점
- 중점적으로 봐줄 내용
- 변수명 괜찮나요
- 로직이 좀 더럽나요
- 가독성이 좀 그런가요?
